### PR TITLE
feat: use signer address if deployer not set

### DIFF
--- a/scripts/deployments/core/deterministic-deploy-zeta-connector.ts
+++ b/scripts/deployments/core/deterministic-deploy-zeta-connector.ts
@@ -9,18 +9,16 @@ import { ZETA_CONNECTOR_SALT_NUMBER_ETH, ZETA_CONNECTOR_SALT_NUMBER_NON_ETH } fr
 import { isEthNetworkName } from "../../../lib/contracts.helpers";
 import { deployContractToAddress, saltToHex } from "../../../lib/ImmutableCreate2Factory/ImmutableCreate2Factory.helpers";
 
-const DEPLOYER_ADDRESS = process.env.DEPLOYER_ADDRESS ?? "";
 
 export async function deterministicDeployZetaConnector() {
   if (!isNetworkName(network.name)) {
     throw new Error(`network.name: ${network.name} isn't supported.`);
   }
-  if (DEPLOYER_ADDRESS === "") {
-    throw new Error(`DEPLOYER_ADDRESS env variable isn't set.`);
-  }
-
+  
   const accounts = await ethers.getSigners();
   const [signer] = accounts;
+  
+  const DEPLOYER_ADDRESS = process.env.DEPLOYER_ADDRESS || signer.address;
 
   const saltNumber = isEthNetworkName(network.name)
     ? ZETA_CONNECTOR_SALT_NUMBER_ETH

--- a/scripts/deployments/core/deterministic-deploy-zeta-token.ts
+++ b/scripts/deployments/core/deterministic-deploy-zeta-token.ts
@@ -13,18 +13,16 @@ import {
 import { isEthNetworkName } from "../../../lib/contracts.helpers";
 import { deployContractToAddress, saltToHex } from "../../../lib/ImmutableCreate2Factory/ImmutableCreate2Factory.helpers";
 
-const DEPLOYER_ADDRESS = process.env.DEPLOYER_ADDRESS ?? "";
 
 export async function deterministicDeployZetaToken() {
   if (!isNetworkName(network.name)) {
     throw new Error(`network.name: ${network.name} isn't supported.`);
   }
-  if (DEPLOYER_ADDRESS === "") {
-    throw new Error(`DEPLOYER_ADDRESS env variable isn't set.`);
-  }
-
+  
   const accounts = await ethers.getSigners();
   const [signer] = accounts;
+  
+  const DEPLOYER_ADDRESS = process.env.DEPLOYER_ADDRESS || signer.address;
 
   const saltNumber = isEthNetworkName(network.name) ? ZETA_TOKEN_SALT_NUMBER_ETH : ZETA_TOKEN_SALT_NUMBER_NON_ETH;
   const saltStr = BigNumber.from(saltNumber).toHexString();

--- a/scripts/deployments/tools/deterministic-deploy-zeta-consumer-v2.ts
+++ b/scripts/deployments/tools/deterministic-deploy-zeta-consumer-v2.ts
@@ -8,8 +8,6 @@ import { getAddress } from "../../../lib/address.helpers";
 import { ZETA_CONSUMER_SALT_NUMBER } from "../../../lib/contracts.constants";
 import { deployContractToAddress, saltToHex } from "../../../lib/ImmutableCreate2Factory/ImmutableCreate2Factory.helpers";
 
-const DEPLOYER_ADDRESS = process.env.DEPLOYER_ADDRESS ?? "";
-
 export async function deterministicDeployZetaConsumer() {
   if (!isNetworkName(network.name)) {
     throw new Error(`network.name: ${network.name} isn't supported.`);
@@ -17,6 +15,8 @@ export async function deterministicDeployZetaConsumer() {
 
   const accounts = await ethers.getSigners();
   const [signer] = accounts;
+
+  const DEPLOYER_ADDRESS = process.env.DEPLOYER_ADDRESS || signer.address;
 
   const saltNumber = ZETA_CONSUMER_SALT_NUMBER;
   const saltStr = BigNumber.from(saltNumber).toHexString();

--- a/scripts/deployments/tools/deterministic-get-salt-zeta-connector.ts
+++ b/scripts/deployments/tools/deterministic-get-salt-zeta-connector.ts
@@ -1,19 +1,23 @@
 import { isNetworkName } from "@zetachain/addresses";
 import { ZetaConnectorEth__factory, ZetaConnectorNonEth__factory } from "../../../typechain-types";
 import { BigNumber } from "ethers";
-import { network } from "hardhat";
+import { ethers, network } from "hardhat";
 
 import { getAddress } from "../../../lib/address.helpers";
 import { isEthNetworkName } from "../../../lib/contracts.helpers";
 import { calculateBestSalt } from "../../../lib/deterministic-deploy.helpers";
 
 const MAX_ITERATIONS = BigNumber.from(100000);
-const DEPLOYER_ADDRESS = process.env.DEPLOYER_ADDRESS ?? "";
 
 export async function deterministicDeployGetSaltZetaConnector() {
   if (!isNetworkName(network.name)) {
     throw new Error(`network.name: ${network.name} isn't supported.`);
   }
+
+  const accounts = await ethers.getSigners();
+  const [signer] = accounts;
+
+  const DEPLOYER_ADDRESS = process.env.DEPLOYER_ADDRESS || signer.address;
 
   const zetaToken = getAddress("zetaToken");
   const tss = getAddress("tss");

--- a/scripts/deployments/tools/deterministic-get-salt-zeta-token.ts
+++ b/scripts/deployments/tools/deterministic-get-salt-zeta-token.ts
@@ -1,7 +1,7 @@
 import { isNetworkName } from "@zetachain/addresses";
 import { ZetaEth__factory, ZetaNonEth__factory } from "../../../typechain-types";
 import { BigNumber } from "ethers";
-import { network } from "hardhat";
+import { ethers, network } from "hardhat";
 
 import { getAddress } from "../../../lib/address.helpers";
 import { ZETA_INITIAL_SUPPLY } from "../../../lib/contracts.constants";
@@ -9,12 +9,16 @@ import { isEthNetworkName } from "../../../lib/contracts.helpers";
 import { calculateBestSalt } from "../../../lib/deterministic-deploy.helpers";
 
 const MAX_ITERATIONS = BigNumber.from(100000);
-const DEPLOYER_ADDRESS = process.env.DEPLOYER_ADDRESS ?? "";
 
 export async function deterministicDeployGetSaltZetaToken() {
   if (!isNetworkName(network.name)) {
     throw new Error(`network.name: ${network.name} isn't supported.`);
   }
+
+  const accounts = await ethers.getSigners();
+  const [signer] = accounts;
+
+  const DEPLOYER_ADDRESS = process.env.DEPLOYER_ADDRESS || signer.address;
 
   const tss = getAddress("tss");
   const tssUpdater = getAddress("tssUpdater");


### PR DESCRIPTION
Use signer address if deployer not set. Looks like deploying zeta token works

```
npx hardhat run scripts/deployments/core/deterministic-deploy-zeta-token.ts --network polygon-mumbai 

Getting tss address from athens: polygon-mumbai.
Getting tssUpdater address from athens: polygon-mumbai.
Getting immutableCreate2Factory address from athens: polygon-mumbai.
SaltHex: 0x2cD3D070aE1BD365909dD859d29F387AA96911e1307837326533000000000000
Deployed zetaToken. Address: 0xF458c3f2e5550692Ee9108368353Ebddf433447f
Constructor Args [
  '0x7c125C1d515b8945841b3d5144a060115C58725F',
  '0x7274d1d5dddef36aac53dd45b93487ce01ef0a55'
]
```