### PR TITLE
chore: run hardhat clean before test

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "clean": "npx hardhat clean",
     "generate:interfaces": "yarn clean && yarn compile",
     "generate:go": "yarn compile && ./scripts/generate_go.sh",
-    "test": "npx hardhat test",
+    "test": "npx hardhat clean && npx hardhat test",
     "tsc:watch": "npx tsc --watch",
     "prepublishOnly": "npx tsc"
   },


### PR DESCRIPTION
If you forget to `clean` first, a test might fail.