### PR TITLE
ci: prepublish runs yarn build, removed yarn build from workflow

### DIFF
--- a/.github/workflows/publish-npm.yaml
+++ b/.github/workflows/publish-npm.yaml
@@ -21,9 +21,6 @@ jobs:
       - name: Install Dependencies
         run: yarn install
 
-      - name: Build
-        run: yarn build
-
       - name: Determine NPM Tag
         id: determine-npm-tag
         run: |

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "test": "npx hardhat clean && npx hardhat test",
     "tsc:watch": "npx tsc --watch",
     "build": "npx del-cli dist && tsc || exit 0 && npx del-cli './dist/typechain-types/**/*.js' && cpx data/**/* dist/data",
-    "prepublish": "yarn build"
+    "prepublishOnly": "yarn build"
   },
   "types": "./dist/typechain-types/index.d.ts",
   "version": "0.0.7"

--- a/package.json
+++ b/package.json
@@ -76,9 +76,8 @@
     "lint:fix": "npx eslint . --ext .js,.ts,.json --fix",
     "test": "npx hardhat clean && npx hardhat test",
     "tsc:watch": "npx tsc --watch",
-    "prebuild": "npx del-cli dist",
-    "build": "tsc || exit 0",
-    "postbuild": "npx del-cli './dist/typechain-types/**/*.js' && cpx data/**/* dist/data"
+    "build": "npx del-cli dist && tsc || exit 0 && npx del-cli './dist/typechain-types/**/*.js' && cpx data/**/* dist/data",
+    "prepublish": "yarn build"
   },
   "types": "./dist/typechain-types/index.d.ts",
   "version": "0.0.7"

--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     "generate:interfaces": "yarn clean && yarn compile",
     "lint": "npx eslint . --ext .js,.ts",
     "lint:fix": "npx eslint . --ext .js,.ts,.json --fix",
-    "prepublishOnly": "npx tsc",
     "test": "npx hardhat clean && npx hardhat test",
     "tsc:watch": "npx tsc --watch",
     "prebuild": "npx del-cli dist",


### PR DESCRIPTION
* Moved build logic into `yarn build`
* `prepublish` now runs `yarn build`
* Removed `yarn build` from npm publishing workflow