### PR TITLE
fix: point types in `package.json` to the types in `lib`

### DIFF
--- a/lib/address.tools.ts
+++ b/lib/address.tools.ts
@@ -7,6 +7,7 @@ export const addresses = JSON.parse(
 
 export declare type ZetaProtocolAddress =
   | "connector"
+  | "erc20Custody"
   | "immutableCreate2Factory"
   | "tss"
   | "tssUpdater"
@@ -16,6 +17,7 @@ export declare type ZetaProtocolAddress =
 
 export const zetaProtocolAddress: ZetaProtocolAddress[] = [
   "connector",
+  "erc20Custody",
   "immutableCreate2Factory",
   "tss",
   "tssUpdater",
@@ -26,7 +28,13 @@ export const zetaProtocolAddress: ZetaProtocolAddress[] = [
 export const isZetaProtocolAddress = (str: string): str is ZetaProtocolAddress =>
   zetaProtocolAddress.includes(str as ZetaProtocolAddress);
 
-export declare type ZetaZEVMAddress = "geth" | "systemContract" | "tbnb" | "tmatic";
+export declare type ZetaZEVMAddress =
+  | "zrc20"
+  | "systemContract"
+  | "fungibleModule"
+  | "uniswapv2Factory"
+  | "uniswapv2Router02";
+
 export declare type ZetaProtocolTestNetwork =
   | "baobab_testnet"
   | "bsc_testnet"

--- a/lib/address.tools.ts
+++ b/lib/address.tools.ts
@@ -29,11 +29,11 @@ export const isZetaProtocolAddress = (str: string): str is ZetaProtocolAddress =
   zetaProtocolAddress.includes(str as ZetaProtocolAddress);
 
 export declare type ZetaZEVMAddress =
-  | "zrc20"
-  | "systemContract"
   | "fungibleModule"
+  | "systemContract"
   | "uniswapv2Factory"
-  | "uniswapv2Router02";
+  | "uniswapv2Router02"
+  | "zrc20";
 
 export declare type ZetaProtocolTestNetwork =
   | "baobab_testnet"

--- a/package.json
+++ b/package.json
@@ -69,16 +69,16 @@
     "registry": "https://registry.npmjs.org/"
   },
   "scripts": {
+    "build": "yarn clean && yarn compile && npx del-cli dist abi && tsc || exit 0 && npx del-cli './dist/typechain-types/**/*.js' && npx cpx './data/**/*' dist/data && npx cpx './artifacts/contracts/**/*' ./abi && npx del-cli './abi/**/*.dbg.json'",
     "clean": "npx hardhat clean",
     "compile": "npx hardhat compile",
     "generate:go": "yarn compile && ./scripts/generate_go.sh",
     "generate:interfaces": "yarn clean && yarn compile",
     "lint": "npx eslint . --ext .js,.ts",
     "lint:fix": "npx eslint . --ext .js,.ts,.json --fix",
+    "prepublishOnly": "yarn build",
     "test": "npx hardhat clean && npx hardhat test",
-    "tsc:watch": "npx tsc --watch",
-    "build": "yarn clean && yarn compile && npx del-cli dist abi && tsc || exit 0 && npx del-cli './dist/typechain-types/**/*.js' && npx cpx './data/**/*' dist/data && npx cpx './artifacts/contracts/**/*' ./abi && npx del-cli './abi/**/*.dbg.json'",
-    "prepublishOnly": "yarn build"
+    "tsc:watch": "npx tsc --watch"
   },
   "types": "./dist/lib/index.d.ts",
   "version": "0.0.7"

--- a/package.json
+++ b/package.json
@@ -80,6 +80,6 @@
     "build": "yarn clean && yarn compile && npx del-cli dist abi && tsc || exit 0 && npx del-cli './dist/typechain-types/**/*.js' && npx cpx './data/**/*' dist/data && npx cpx './artifacts/contracts/**/*' ./abi && npx del-cli './abi/**/*.dbg.json'",
     "prepublishOnly": "yarn build"
   },
-  "types": "./dist/typechain-types/index.d.ts",
+  "types": "./dist/lib/index.d.ts",
   "version": "0.0.7"
 }


### PR DESCRIPTION
`getAddress` and other helper functions when imported are not being recognized by TypeScript, because `types` were pointing to `typechain-types`.

I've also updated some types related to addresses.