### PR TITLE
ci: error message when the generate check fails

### DIFF
--- a/.github/workflows/generated-files.yaml
+++ b/.github/workflows/generated-files.yaml
@@ -28,14 +28,15 @@ jobs:
           tar -zxvf geth-alltools-linux-amd64-1.11.5-a38f4108.tar.gz
           sudo mv geth-alltools-linux-amd64-1.11.5-a38f4108/abigen /usr/local/bin/
 
-      - name: Generate Go packages
+      - name: Generate Go packages and typechain-types
         run: |
-          yarn generate:go
-
-      - name: Compile contracts
-        run: |
-          yarn compile
+          yarn generate
 
       - name: Check for changes
         run: |
-          git diff --exit-code --ignore-space-change --ignore-all-space --ignore-cr-at-eol -- pkg typechain-types
+          git diff --exit-code --ignore-space-change --ignore-all-space --ignore-cr-at-eol -- pkg typechain-types; then
+            echo "Generated Go files are up-to-date."
+          else
+            echo "::error::Generated files are not up-to-date. Please run 'yarn generate' locally and commit any changes."
+            exit 1
+          fi

--- a/package.json
+++ b/package.json
@@ -71,8 +71,7 @@
     "build": "yarn clean && yarn compile && npx del-cli dist abi && tsc || exit 0 && npx del-cli './dist/typechain-types/**/*.js' && npx cpx './data/**/*' dist/data && npx cpx './artifacts/contracts/**/*' ./abi && npx del-cli './abi/**/*.dbg.json'",
     "clean": "npx hardhat clean",
     "compile": "yarn clean && npx hardhat compile",
-    "generate:go": "yarn compile && ./scripts/generate_go.sh",
-    "generate:interfaces": "yarn clean && yarn compile",
+    "generate": "yarn compile && ./scripts/generate_go.sh",
     "lint": "npx eslint . --ext .js,.ts",
     "lint:fix": "npx eslint . --ext .js,.ts,.json --fix",
     "prepublishOnly": "yarn build",
@@ -82,4 +81,3 @@
   "types": "./dist/lib/index.d.ts",
   "version": "0.0.8"
 }
-

--- a/readme.md
+++ b/readme.md
@@ -73,7 +73,7 @@ to the `artifacts` directory.
 To generate Go bindings for the Solidity contracts, run the following command:
 
 ```
-yarn generate:go
+yarn generate
 ```
 
 This will use `abigen` to generate Go bindings for the contracts and output the


### PR DESCRIPTION
* added error message when the "Generated Files" workflow fails
* renamed `yarn generate:go` to `yarn generate`, because it generates both Go packages and typechain-types
* removed `yarn generate:interfaces` as it's the same as `yarn compile`