### PR TITLE
chore: updating code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*     @andresaiello @lucas-janon @fadeev
+*     @andresaiello @brewmaster012 @lumtis @charliemc0 @fadeev


### PR DESCRIPTION
Updating code owners to require approval from Protocol team before anything can be merged in. 

This is to ensure changes to the protocol contracts are coordinated with the protocol team and tracked for security purposes. 