### PR TITLE
feat: Canonical addresses JSON

### DIFF
--- a/data/addresses.mainnet.json
+++ b/data/addresses.mainnet.json
@@ -1,5 +1,47 @@
 [
   {
+    "address": "0x000007Cf399229b2f5A4D043F20E90C9C98B7C6a",
+    "category": "messaging",
+    "chain_id": 1,
+    "chain_name": "eth_mainnet",
+    "type": "connector"
+  },
+  {
+    "address": "0x0000030Ec64DF25301d8414eE5a29588C4B0dE10",
+    "category": "omnichain",
+    "chain_id": 1,
+    "chain_name": "eth_mainnet",
+    "type": "erc20Custody"
+  },
+  {
+    "address": "0xaeB6dDB7708467814D557e340283248be8E43124",
+    "category": "messaging",
+    "chain_id": 1,
+    "chain_name": "eth_mainnet",
+    "type": "pauser"
+  },
+  {
+    "address": "0x70e967acFcC17c3941E87562161406d41676FD83",
+    "category": "omnichain",
+    "chain_id": 1,
+    "chain_name": "eth_mainnet",
+    "type": "tss"
+  },
+  {
+    "address": "0xaeB6dDB7708467814D557e340283248be8E43124",
+    "category": "omnichain",
+    "chain_id": 1,
+    "chain_name": "eth_mainnet",
+    "type": "tssUpdater"
+  },
+  {
+    "address": "0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f",
+    "category": "messaging",
+    "chain_id": 1,
+    "chain_name": "eth_mainnet",
+    "type": "uniswapV2Factory"
+  },
+  {
     "address": "0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f",
     "category": "messaging",
     "chain_id": 1,
@@ -14,6 +56,13 @@
     "type": "uniswapV2Router02"
   },
   {
+    "address": "0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f",
+    "category": "messaging",
+    "chain_id": 1,
+    "chain_name": "eth_mainnet",
+    "type": "uniswapV3Factory"
+  },
+  {
     "address": "0xE592427A0AEce92De3Edee1F18E0157C05861564",
     "category": "messaging",
     "chain_id": 1,
@@ -21,11 +70,39 @@
     "type": "uniswapV3Router"
   },
   {
-    "address": "0x70e967acFcC17c3941E87562161406d41676FD83",
-    "category": "omnichain",
+    "address": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+    "category": "messaging",
     "chain_id": 1,
     "chain_name": "eth_mainnet",
-    "type": "tss"
+    "type": "weth9"
+  },
+  {
+    "address": "0xf091867EC603A6628eD83D274E835539D82e9cc8",
+    "category": "messaging",
+    "chain_id": 1,
+    "chain_name": "eth_mainnet",
+    "type": "zetaToken"
+  },
+  {
+    "address": "0x000063A6e758D9e2f438d430108377564cf4077D",
+    "category": "messaging",
+    "chain_id": 56,
+    "chain_name": "bsc_mainnet",
+    "type": "connector"
+  },
+  {
+    "address": "0x00000fF8fA992424957F97688015814e707A0115",
+    "category": "omnichain",
+    "chain_id": 56,
+    "chain_name": "bsc_mainnet",
+    "type": "erc20Custody"
+  },
+  {
+    "address": "0xaf28a257D292e7f0E531073f70a175b57E0261a8",
+    "category": "messaging",
+    "chain_id": 56,
+    "chain_name": "bsc_mainnet",
+    "type": "pauser"
   },
   {
     "address": "0x70e967acFcC17c3941E87562161406d41676FD83",
@@ -35,18 +112,32 @@
     "type": "tss"
   },
   {
-    "address": "0x70e967acFcC17c3941E87562161406d41676FD83",
+    "address": "0xaf28a257D292e7f0E531073f70a175b57E0261a8",
     "category": "omnichain",
-    "chain_id": 8332,
-    "chain_name": "btc_mainnet",
-    "type": "tss"
+    "chain_id": 56,
+    "chain_name": "bsc_mainnet",
+    "type": "tssUpdater"
   },
   {
-    "address": "0x70e967acFcC17c3941E87562161406d41676FD83",
+    "address": "0x0000028a2eB8346cd5c0267856aB7594B7a55308",
+    "category": "messaging",
+    "chain_id": 56,
+    "chain_name": "bsc_mainnet",
+    "type": "zetaToken"
+  },
+  {
+    "address": "0x239e96c8f17C85c30100AC26F635Ea15f23E9c67",
+    "category": "messaging",
+    "chain_id": 7000,
+    "chain_name": "zeta_mainnet",
+    "type": "connector"
+  },
+  {
+    "address": "0x735b14BB79463307AAcBED86DAf3322B1e6226aB",
     "category": "omnichain",
     "chain_id": 7000,
     "chain_name": "zeta_mainnet",
-    "type": "tss"
+    "type": "fungibleModule"
   },
   {
     "address": "0x91d18e54DAf4F677cB28167158d6dd21F6aB3921",
@@ -56,11 +147,46 @@
     "type": "systemContract"
   },
   {
-    "address": "0x239e96c8f17C85c30100AC26F635Ea15f23E9c67",
+    "address": "0x70e967acFcC17c3941E87562161406d41676FD83",
+    "category": "omnichain",
+    "chain_id": 7000,
+    "chain_name": "zeta_mainnet",
+    "type": "tss"
+  },
+  {
+    "address": "0x9fd96203f7b22bCF72d9DCb40ff98302376cE09c",
+    "category": "omnichain",
+    "chain_id": 7000,
+    "chain_name": "zeta_mainnet",
+    "type": "uniswapV2Factory"
+  },
+  {
+    "address": "0x9fd96203f7b22bCF72d9DCb40ff98302376cE09c",
     "category": "messaging",
     "chain_id": 7000,
     "chain_name": "zeta_mainnet",
-    "type": "connector"
+    "type": "uniswapV2Factory"
+  },
+  {
+    "address": "0x2ca7d64A7EFE2D62A725E2B35Cf7230D6677FfEe",
+    "category": "omnichain",
+    "chain_id": 7000,
+    "chain_name": "zeta_mainnet",
+    "type": "uniswapV2Router02"
+  },
+  {
+    "address": "0x9fd96203f7b22bCF72d9DCb40ff98302376cE09c",
+    "category": "messaging",
+    "chain_id": 7000,
+    "chain_name": "zeta_mainnet",
+    "type": "uniswapV3Factory"
+  },
+  {
+    "address": "0x5F0b1a82749cb4E2278EC87F8BF6B618dC71a8bf",
+    "category": "omnichain",
+    "chain_id": 7000,
+    "chain_name": "zeta_mainnet",
+    "type": "zetaToken"
   },
   {
     "address": "0x05BA149A7bd6dC1F937fA9046A9e05C05f3b18b0",
@@ -154,136 +280,10 @@
     "type": "zrc20"
   },
   {
-    "address": "0x9fd96203f7b22bCF72d9DCb40ff98302376cE09c",
+    "address": "0x70e967acFcC17c3941E87562161406d41676FD83",
     "category": "omnichain",
-    "chain_id": 7000,
-    "chain_name": "zeta_mainnet",
-    "type": "uniswapV2Factory"
-  },
-  {
-    "address": "0x5F0b1a82749cb4E2278EC87F8BF6B618dC71a8bf",
-    "category": "omnichain",
-    "chain_id": 7000,
-    "chain_name": "zeta_mainnet",
-    "type": "zetaToken"
-  },
-  {
-    "address": "0x2ca7d64A7EFE2D62A725E2B35Cf7230D6677FfEe",
-    "category": "omnichain",
-    "chain_id": 7000,
-    "chain_name": "zeta_mainnet",
-    "type": "uniswapV2Router02"
-  },
-  {
-    "address": "0x735b14BB79463307AAcBED86DAf3322B1e6226aB",
-    "category": "omnichain",
-    "chain_id": 7000,
-    "chain_name": "zeta_mainnet",
-    "type": "fungibleModule"
-  },
-  {
-    "address": "0x0000028a2eB8346cd5c0267856aB7594B7a55308",
-    "category": "messaging",
-    "chain_id": 56,
-    "chain_name": "bsc_mainnet",
-    "type": "zetaToken"
-  },
-  {
-    "address": "0x000063A6e758D9e2f438d430108377564cf4077D",
-    "category": "messaging",
-    "chain_id": 56,
-    "chain_name": "bsc_mainnet",
-    "type": "connector"
-  },
-  {
-    "address": "0x00000fF8fA992424957F97688015814e707A0115",
-    "category": "omnichain",
-    "chain_id": 56,
-    "chain_name": "bsc_mainnet",
-    "type": "erc20Custody"
-  },
-  {
-    "address": "0xf091867EC603A6628eD83D274E835539D82e9cc8",
-    "category": "messaging",
-    "chain_id": 1,
-    "chain_name": "eth_mainnet",
-    "type": "zetaToken"
-  },
-  {
-    "address": "0x000007Cf399229b2f5A4D043F20E90C9C98B7C6a",
-    "category": "messaging",
-    "chain_id": 1,
-    "chain_name": "eth_mainnet",
-    "type": "connector"
-  },
-  {
-    "address": "0x0000030Ec64DF25301d8414eE5a29588C4B0dE10",
-    "category": "omnichain",
-    "chain_id": 1,
-    "chain_name": "eth_mainnet",
-    "type": "erc20Custody"
-  },
-  {
-    "address": "0xaeB6dDB7708467814D557e340283248be8E43124",
-    "category": "omnichain",
-    "chain_id": 1,
-    "chain_name": "eth_mainnet",
-    "type": "tssUpdater"
-  },
-  {
-    "address": "0xaf28a257D292e7f0E531073f70a175b57E0261a8",
-    "category": "omnichain",
-    "chain_id": 56,
-    "chain_name": "bsc_mainnet",
-    "type": "tssUpdater"
-  },
-  {
-    "address": "0xaeB6dDB7708467814D557e340283248be8E43124",
-    "category": "messaging",
-    "chain_id": 1,
-    "chain_name": "eth_mainnet",
-    "type": "pauser"
-  },
-  {
-    "address": "0xaf28a257D292e7f0E531073f70a175b57E0261a8",
-    "category": "messaging",
-    "chain_id": 56,
-    "chain_name": "bsc_mainnet",
-    "type": "pauser"
-  },
-  {
-    "address": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
-    "category": "messaging",
-    "chain_id": 1,
-    "chain_name": "eth_mainnet",
-    "type": "weth9"
-  },
-  {
-    "address": "0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f",
-    "category": "messaging",
-    "chain_id": 1,
-    "chain_name": "eth_mainnet",
-    "type": "uniswapV2Factory"
-  },
-  {
-    "address": "0x9fd96203f7b22bCF72d9DCb40ff98302376cE09c",
-    "category": "messaging",
-    "chain_id": 7000,
-    "chain_name": "zeta_mainnet",
-    "type": "uniswapV2Factory"
-  },
-  {
-    "address": "0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f",
-    "category": "messaging",
-    "chain_id": 1,
-    "chain_name": "eth_mainnet",
-    "type": "uniswapV3Factory"
-  },
-  {
-    "address": "0x9fd96203f7b22bCF72d9DCb40ff98302376cE09c",
-    "category": "messaging",
-    "chain_id": 7000,
-    "chain_name": "zeta_mainnet",
-    "type": "uniswapV3Factory"
+    "chain_id": 8332,
+    "chain_name": "btc_mainnet",
+    "type": "tss"
   }
 ]

--- a/data/addresses.testnet.json
+++ b/data/addresses.testnet.json
@@ -1,52 +1,45 @@
 [
   {
-    "address": "0x8eAc517b92eeE82177a83851268F13109878f8c4",
+    "address": "0x00005e3125aba53c5652f9f0ce1a4cf91d8b15ea",
     "category": "messaging",
     "chain_id": 5,
     "chain_name": "goerli_testnet",
-    "type": "zetaTokenConsumerUniV2"
+    "type": "connector"
   },
   {
-    "address": "0x7e792f3736751e168864106AdbAC50152641A927",
-    "category": "messaging",
-    "chain_id": 80001,
-    "chain_name": "mumbai_testnet",
-    "type": "zetaTokenConsumerUniV3"
+    "address": "0x000047f11c6e42293f433c82473532e869ce4ec5",
+    "category": "omnichain",
+    "chain_id": 5,
+    "chain_name": "goerli_testnet",
+    "type": "erc20Custody"
   },
   {
-    "address": "0xFB2fCE3CCca19F0f764Ed8aa26C62181E3dA04C5",
+    "address": "0x55122f7590164Ac222504436943FAB17B62F5d7d",
     "category": "messaging",
-    "chain_id": 97,
-    "chain_name": "bsc_testnet",
-    "type": "zetaTokenConsumerUniV3"
+    "chain_id": 5,
+    "chain_name": "goerli_testnet",
+    "type": "pauser"
   },
   {
-    "address": "0x8954AfA98594b838bda56FE4C12a09D7739D179b",
-    "category": "messaging",
-    "chain_id": 80001,
-    "chain_name": "mumbai_testnet",
-    "type": "uniswapV2Router02"
+    "address": "0x8531a5aB847ff5B22D855633C25ED1DA3255247e",
+    "category": "omnichain",
+    "chain_id": 5,
+    "chain_name": "goerli_testnet",
+    "type": "tss"
   },
   {
-    "address": "0xE592427A0AEce92De3Edee1F18E0157C05861564",
-    "category": "messaging",
-    "chain_id": 80001,
-    "chain_name": "mumbai_testnet",
-    "type": "uniswapV3Router"
+    "address": "0x55122f7590164Ac222504436943FAB17B62F5d7d",
+    "category": "omnichain",
+    "chain_id": 5,
+    "chain_name": "goerli_testnet",
+    "type": "tssUpdater"
   },
   {
-    "address": "0x9Ac64Cc6e4415144C455BD8E4837Fea55603e5c3",
+    "address": "0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f",
     "category": "messaging",
-    "chain_id": 97,
-    "chain_name": "bsc_testnet",
-    "type": "uniswapV2Router02"
-  },
-  {
-    "address": "0x9a489505a00cE272eAa5e07Dba6491314CaE3796",
-    "category": "messaging",
-    "chain_id": 97,
-    "chain_name": "bsc_testnet",
-    "type": "uniswapV3Router"
+    "chain_id": 5,
+    "chain_name": "goerli_testnet",
+    "type": "uniswapV2Factory"
   },
   {
     "address": "0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D",
@@ -56,6 +49,13 @@
     "type": "uniswapV2Router02"
   },
   {
+    "address": "0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f",
+    "category": "messaging",
+    "chain_id": 5,
+    "chain_name": "goerli_testnet",
+    "type": "uniswapV3Factory"
+  },
+  {
     "address": "0xE592427A0AEce92De3Edee1F18E0157C05861564",
     "category": "messaging",
     "chain_id": 5,
@@ -63,11 +63,46 @@
     "type": "uniswapV3Router"
   },
   {
-    "address": "0x8531a5aB847ff5B22D855633C25ED1DA3255247e",
-    "category": "omnichain",
+    "address": "0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6",
+    "category": "messaging",
     "chain_id": 5,
     "chain_name": "goerli_testnet",
-    "type": "tss"
+    "type": "weth9"
+  },
+  {
+    "address": "0x0000c304d2934c00db1d51995b9f6996affd17c0",
+    "category": "messaging",
+    "chain_id": 5,
+    "chain_name": "goerli_testnet",
+    "type": "zetaToken"
+  },
+  {
+    "address": "0x8eAc517b92eeE82177a83851268F13109878f8c4",
+    "category": "messaging",
+    "chain_id": 5,
+    "chain_name": "goerli_testnet",
+    "type": "zetaTokenConsumerUniV2"
+  },
+  {
+    "address": "0x0000ecb8cdd25a18f12daa23f6422e07fbf8b9e1",
+    "category": "messaging",
+    "chain_id": 97,
+    "chain_name": "bsc_testnet",
+    "type": "connector"
+  },
+  {
+    "address": "0x0000a7db254145767262c6a81a7ee1650684258e",
+    "category": "omnichain",
+    "chain_id": 97,
+    "chain_name": "bsc_testnet",
+    "type": "erc20Custody"
+  },
+  {
+    "address": "0x55122f7590164Ac222504436943FAB17B62F5d7d",
+    "category": "messaging",
+    "chain_id": 97,
+    "chain_name": "bsc_testnet",
+    "type": "pauser"
   },
   {
     "address": "0x8531a5aB847ff5B22D855633C25ED1DA3255247e",
@@ -77,18 +112,74 @@
     "type": "tss"
   },
   {
-    "address": "0x8531a5aB847ff5B22D855633C25ED1DA3255247e",
+    "address": "0x55122f7590164Ac222504436943FAB17B62F5d7d",
     "category": "omnichain",
-    "chain_id": 80001,
-    "chain_name": "mumbai_testnet",
-    "type": "tss"
+    "chain_id": 97,
+    "chain_name": "bsc_testnet",
+    "type": "tssUpdater"
   },
   {
-    "address": "tb1qy9pqmk2pd9sv63g27jt8r657wy0d9ueeh0nqur",
+    "address": "0xB7926C0430Afb07AA7DEfDE6DA862aE0Bde767bc",
+    "category": "messaging",
+    "chain_id": 97,
+    "chain_name": "bsc_testnet",
+    "type": "uniswapV2Factory"
+  },
+  {
+    "address": "0x9Ac64Cc6e4415144C455BD8E4837Fea55603e5c3",
+    "category": "messaging",
+    "chain_id": 97,
+    "chain_name": "bsc_testnet",
+    "type": "uniswapV2Router02"
+  },
+  {
+    "address": "0xB7926C0430Afb07AA7DEfDE6DA862aE0Bde767bc",
+    "category": "messaging",
+    "chain_id": 97,
+    "chain_name": "bsc_testnet",
+    "type": "uniswapV3Factory"
+  },
+  {
+    "address": "0x9a489505a00cE272eAa5e07Dba6491314CaE3796",
+    "category": "messaging",
+    "chain_id": 97,
+    "chain_name": "bsc_testnet",
+    "type": "uniswapV3Router"
+  },
+  {
+    "address": "0xae13d989daC2f0dEbFf460aC112a837C89BAa7cd",
+    "category": "messaging",
+    "chain_id": 97,
+    "chain_name": "bsc_testnet",
+    "type": "weth9"
+  },
+  {
+    "address": "0x0000c9ec4042283e8139c74f4c64bcd1e0b9b54f",
+    "category": "messaging",
+    "chain_id": 97,
+    "chain_name": "bsc_testnet",
+    "type": "zetaToken"
+  },
+  {
+    "address": "0xFB2fCE3CCca19F0f764Ed8aa26C62181E3dA04C5",
+    "category": "messaging",
+    "chain_id": 97,
+    "chain_name": "bsc_testnet",
+    "type": "zetaTokenConsumerUniV3"
+  },
+  {
+    "address": "0x239e96c8f17C85c30100AC26F635Ea15f23E9c67",
+    "category": "messaging",
+    "chain_id": 7001,
+    "chain_name": "zeta_testnet",
+    "type": "connector"
+  },
+  {
+    "address": "0x735b14BB79463307AAcBED86DAf3322B1e6226aB",
     "category": "omnichain",
-    "chain_id": 18332,
-    "chain_name": "btc_testnet",
-    "type": "tss"
+    "chain_id": 7001,
+    "chain_name": "zeta_testnet",
+    "type": "fungibleModule"
   },
   {
     "address": "0xEdf1c3275d13489aCdC6cD6eD246E72458B8795B",
@@ -98,11 +189,39 @@
     "type": "systemContract"
   },
   {
-    "address": "0x239e96c8f17C85c30100AC26F635Ea15f23E9c67",
+    "address": "0x9fd96203f7b22bCF72d9DCb40ff98302376cE09c",
+    "category": "omnichain",
+    "chain_id": 7001,
+    "chain_name": "zeta_testnet",
+    "type": "uniswapV2Factory"
+  },
+  {
+    "address": "0x9fd96203f7b22bCF72d9DCb40ff98302376cE09c",
     "category": "messaging",
     "chain_id": 7001,
     "chain_name": "zeta_testnet",
-    "type": "connector"
+    "type": "uniswapV2Factory"
+  },
+  {
+    "address": "0x2ca7d64A7EFE2D62A725E2B35Cf7230D6677FfEe",
+    "category": "omnichain",
+    "chain_id": 7001,
+    "chain_name": "zeta_testnet",
+    "type": "uniswapV2Router02"
+  },
+  {
+    "address": "0x9fd96203f7b22bCF72d9DCb40ff98302376cE09c",
+    "category": "messaging",
+    "chain_id": 7001,
+    "chain_name": "zeta_testnet",
+    "type": "uniswapV3Factory"
+  },
+  {
+    "address": "0x5F0b1a82749cb4E2278EC87F8BF6B618dC71a8bf",
+    "category": "omnichain",
+    "chain_id": 7001,
+    "chain_name": "zeta_testnet",
+    "type": "zetaToken"
   },
   {
     "address": "0x0cbe0dF132a6c6B4a2974Fa1b7Fb953CF0Cc798a",
@@ -196,137 +315,74 @@
     "type": "zrc20"
   },
   {
-    "address": "0x9fd96203f7b22bCF72d9DCb40ff98302376cE09c",
+    "address": "tb1qy9pqmk2pd9sv63g27jt8r657wy0d9ueeh0nqur",
     "category": "omnichain",
-    "chain_id": 7001,
-    "chain_name": "zeta_testnet",
+    "chain_id": 18332,
+    "chain_name": "btc_testnet",
+    "type": "tss"
+  },
+  {
+    "address": "0x0000ecb8cdd25a18f12daa23f6422e07fbf8b9e1",
+    "category": "messaging",
+    "chain_id": 80001,
+    "chain_name": "mumbai_testnet",
+    "type": "connector"
+  },
+  {
+    "address": "0x0000a7db254145767262c6a81a7ee1650684258e",
+    "category": "omnichain",
+    "chain_id": 80001,
+    "chain_name": "mumbai_testnet",
+    "type": "erc20Custody"
+  },
+  {
+    "address": "0x55122f7590164Ac222504436943FAB17B62F5d7d",
+    "category": "messaging",
+    "chain_id": 80001,
+    "chain_name": "mumbai_testnet",
+    "type": "pauser"
+  },
+  {
+    "address": "0x8531a5aB847ff5B22D855633C25ED1DA3255247e",
+    "category": "omnichain",
+    "chain_id": 80001,
+    "chain_name": "mumbai_testnet",
+    "type": "tss"
+  },
+  {
+    "address": "0x55122f7590164Ac222504436943FAB17B62F5d7d",
+    "category": "omnichain",
+    "chain_id": 80001,
+    "chain_name": "mumbai_testnet",
+    "type": "tssUpdater"
+  },
+  {
+    "address": "0x5757371414417b8C6CAad45bAeF941aBc7d3Ab32",
+    "category": "messaging",
+    "chain_id": 80001,
+    "chain_name": "mumbai_testnet",
     "type": "uniswapV2Factory"
   },
   {
-    "address": "0x5F0b1a82749cb4E2278EC87F8BF6B618dC71a8bf",
-    "category": "omnichain",
-    "chain_id": 7001,
-    "chain_name": "zeta_testnet",
-    "type": "zetaToken"
-  },
-  {
-    "address": "0x2ca7d64A7EFE2D62A725E2B35Cf7230D6677FfEe",
-    "category": "omnichain",
-    "chain_id": 7001,
-    "chain_name": "zeta_testnet",
+    "address": "0x8954AfA98594b838bda56FE4C12a09D7739D179b",
+    "category": "messaging",
+    "chain_id": 80001,
+    "chain_name": "mumbai_testnet",
     "type": "uniswapV2Router02"
   },
   {
-    "address": "0x735b14BB79463307AAcBED86DAf3322B1e6226aB",
-    "category": "omnichain",
-    "chain_id": 7001,
-    "chain_name": "zeta_testnet",
-    "type": "fungibleModule"
-  },
-  {
-    "address": "0x0000c304d2934c00db1d51995b9f6996affd17c0",
-    "category": "messaging",
-    "chain_id": 5,
-    "chain_name": "goerli_testnet",
-    "type": "zetaToken"
-  },
-  {
-    "address": "0x00005e3125aba53c5652f9f0ce1a4cf91d8b15ea",
-    "category": "messaging",
-    "chain_id": 5,
-    "chain_name": "goerli_testnet",
-    "type": "connector"
-  },
-  {
-    "address": "0x000047f11c6e42293f433c82473532e869ce4ec5",
-    "category": "omnichain",
-    "chain_id": 5,
-    "chain_name": "goerli_testnet",
-    "type": "erc20Custody"
-  },
-  {
-    "address": "0x0000c9ec4042283e8139c74f4c64bcd1e0b9b54f",
+    "address": "0x5757371414417b8C6CAad45bAeF941aBc7d3Ab32",
     "category": "messaging",
     "chain_id": 80001,
     "chain_name": "mumbai_testnet",
-    "type": "zetaToken"
+    "type": "uniswapV3Factory"
   },
   {
-    "address": "0x0000ecb8cdd25a18f12daa23f6422e07fbf8b9e1",
+    "address": "0xE592427A0AEce92De3Edee1F18E0157C05861564",
     "category": "messaging",
     "chain_id": 80001,
     "chain_name": "mumbai_testnet",
-    "type": "connector"
-  },
-  {
-    "address": "0x0000a7db254145767262c6a81a7ee1650684258e",
-    "category": "omnichain",
-    "chain_id": 80001,
-    "chain_name": "mumbai_testnet",
-    "type": "erc20Custody"
-  },
-  {
-    "address": "0x0000c9ec4042283e8139c74f4c64bcd1e0b9b54f",
-    "category": "messaging",
-    "chain_id": 97,
-    "chain_name": "bsc_testnet",
-    "type": "zetaToken"
-  },
-  {
-    "address": "0x0000ecb8cdd25a18f12daa23f6422e07fbf8b9e1",
-    "category": "messaging",
-    "chain_id": 97,
-    "chain_name": "bsc_testnet",
-    "type": "connector"
-  },
-  {
-    "address": "0x0000a7db254145767262c6a81a7ee1650684258e",
-    "category": "omnichain",
-    "chain_id": 97,
-    "chain_name": "bsc_testnet",
-    "type": "erc20Custody"
-  },
-  {
-    "address": "0x55122f7590164Ac222504436943FAB17B62F5d7d",
-    "category": "omnichain",
-    "chain_id": 97,
-    "chain_name": "bsc_testnet",
-    "type": "tssUpdater"
-  },
-  {
-    "address": "0x55122f7590164Ac222504436943FAB17B62F5d7d",
-    "category": "omnichain",
-    "chain_id": 5,
-    "chain_name": "goerli_testnet",
-    "type": "tssUpdater"
-  },
-  {
-    "address": "0x55122f7590164Ac222504436943FAB17B62F5d7d",
-    "category": "omnichain",
-    "chain_id": 80001,
-    "chain_name": "mumbai_testnet",
-    "type": "tssUpdater"
-  },
-  {
-    "address": "0x55122f7590164Ac222504436943FAB17B62F5d7d",
-    "category": "messaging",
-    "chain_id": 5,
-    "chain_name": "goerli_testnet",
-    "type": "pauser"
-  },
-  {
-    "address": "0x55122f7590164Ac222504436943FAB17B62F5d7d",
-    "category": "messaging",
-    "chain_id": 97,
-    "chain_name": "bsc_testnet",
-    "type": "pauser"
-  },
-  {
-    "address": "0x55122f7590164Ac222504436943FAB17B62F5d7d",
-    "category": "messaging",
-    "chain_id": 80001,
-    "chain_name": "mumbai_testnet",
-    "type": "pauser"
+    "type": "uniswapV3Router"
   },
   {
     "address": "0x9c3C9283D3e44854697Cd22D3Faa240Cfb032889",
@@ -336,73 +392,17 @@
     "type": "weth9"
   },
   {
-    "address": "0x5757371414417b8C6CAad45bAeF941aBc7d3Ab32",
+    "address": "0x0000c9ec4042283e8139c74f4c64bcd1e0b9b54f",
     "category": "messaging",
     "chain_id": 80001,
     "chain_name": "mumbai_testnet",
-    "type": "uniswapV2Factory"
+    "type": "zetaToken"
   },
   {
-    "address": "0xae13d989daC2f0dEbFf460aC112a837C89BAa7cd",
-    "category": "messaging",
-    "chain_id": 97,
-    "chain_name": "bsc_testnet",
-    "type": "weth9"
-  },
-  {
-    "address": "0xB7926C0430Afb07AA7DEfDE6DA862aE0Bde767bc",
-    "category": "messaging",
-    "chain_id": 97,
-    "chain_name": "bsc_testnet",
-    "type": "uniswapV2Factory"
-  },
-  {
-    "address": "0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6",
-    "category": "messaging",
-    "chain_id": 5,
-    "chain_name": "goerli_testnet",
-    "type": "weth9"
-  },
-  {
-    "address": "0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f",
-    "category": "messaging",
-    "chain_id": 5,
-    "chain_name": "goerli_testnet",
-    "type": "uniswapV2Factory"
-  },
-  {
-    "address": "0x9fd96203f7b22bCF72d9DCb40ff98302376cE09c",
-    "category": "messaging",
-    "chain_id": 7001,
-    "chain_name": "zeta_testnet",
-    "type": "uniswapV2Factory"
-  },
-  {
-    "address": "0x5757371414417b8C6CAad45bAeF941aBc7d3Ab32",
+    "address": "0x7e792f3736751e168864106AdbAC50152641A927",
     "category": "messaging",
     "chain_id": 80001,
     "chain_name": "mumbai_testnet",
-    "type": "uniswapV3Factory"
-  },
-  {
-    "address": "0xB7926C0430Afb07AA7DEfDE6DA862aE0Bde767bc",
-    "category": "messaging",
-    "chain_id": 97,
-    "chain_name": "bsc_testnet",
-    "type": "uniswapV3Factory"
-  },
-  {
-    "address": "0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f",
-    "category": "messaging",
-    "chain_id": 5,
-    "chain_name": "goerli_testnet",
-    "type": "uniswapV3Factory"
-  },
-  {
-    "address": "0x9fd96203f7b22bCF72d9DCb40ff98302376cE09c",
-    "category": "messaging",
-    "chain_id": 7001,
-    "chain_name": "zeta_testnet",
-    "type": "uniswapV3Factory"
+    "type": "zetaTokenConsumerUniV3"
   }
 ]

--- a/readme.md
+++ b/readme.md
@@ -1,8 +1,7 @@
 # ZetaChain Protocol Contracts
 
-This repository contains the smart contracts for ZetaChain. The smart contracts
-are written in Solidity, and the repository includes scripts to compile the
-contracts and generate Go bindings.
+This repository contains ZetaChain protocol contracts: Solidity source code,
+generated Go bindings, deployed contract addresses and helper utilities.
 
 ## Importing Protocol Contracts
 
@@ -13,6 +12,27 @@ project:
 yarn add --dev @zetachain/protocol-contracts
 ```
 
+Getting the TSS address on BSC testnet:
+
+```ts
+import { getAddress } from "@zetachain/protocol-contracts";
+
+getAddress("tss", "zeta_testnet");
+```
+
+Getting a ZRC-20 BSC USDT on ZetaChain Mainnet Beta:
+
+```ts
+import { getAddress } from "@zetachain/protocol-contracts";
+
+getAddress("zrc20", "zeta_mainnet", "USDT.BSC");
+```
+
+The third argument (symbol) is only used when querying ZRC-20 addresses to
+specify which token address is needed.
+
+To view a table of all contracts visit the [Contract Addresses](https://www.zetachain.com/docs/reference/contracts/) page in the docs.
+
 Importing
 [`ZetaInterfaces`](https://www.zetachain.com/docs/developers/cross-chain-messaging/connector/)
 and `ZetaInteractor` for cross-chain messaging:
@@ -22,9 +42,9 @@ import "@zetachain/protocol-contracts/contracts/evm/interfaces/ZetaInterfaces.so
 import "@zetachain/protocol-contracts/contracts/evm/tools/ZetaInteractor.sol";
 ```
 
-Importing [ZRC20](https://www.zetachain.com/docs/developers/concepts/zrc-20/)
+Importing [ZRC20](https://www.zetachain.com/docs/developers/tokens/zrc20/)
 and the [system
-contract](https://www.zetachain.com/docs/developers/concepts/system-contract/)
+contract](https://www.zetachain.com/docs/developers/omnichain/system-contract/)
 for omni-chain smart contracts:
 
 ```solidity
@@ -33,7 +53,7 @@ import "@zetachain/protocol-contracts/contracts/zevm/interfaces/zContract.sol";
 import "@zetachain/protocol-contracts/contracts/zevm/SystemContract.sol";
 ```
 
-## Prerequisites
+## Prerequisites for Development
 
 Before you can contribute to this project, you must have the following installed:
 
@@ -41,21 +61,6 @@ Before you can contribute to this project, you must have the following installed
 - [Yarn](https://yarnpkg.com/)
 - [jq](https://stedolan.github.io/jq/)
 - [abigen](https://geth.ethereum.org/docs/tools/abigen)
-
-## Getting Started
-
-To get started with this project, you should first clone the repository:
-
-```
-git clone https://github.com/zeta-chain/protocol-contracts
-```
-
-Once you have cloned the repository, you can navigate to the project directory
-and run the following command to install the project dependencies:
-
-```
-yarn
-```
 
 ## Compiling Contracts
 
@@ -68,9 +73,9 @@ yarn compile
 This will compile the Solidity contracts and output the resulting JSON artifacts
 to the `artifacts` directory.
 
-## Generating Go Bindings
+## Generating Go Bindings and Contract Addresses
 
-To generate Go bindings for the Solidity contracts, run the following command:
+To generate Go bindings for the Solidity contracts and fetch, run the following command:
 
 ```
 yarn generate

--- a/tasks/addresses.ts
+++ b/tasks/addresses.ts
@@ -14,6 +14,14 @@ declare const hre: any;
 
 type Network = "zeta_mainnet" | "zeta_testnet";
 
+type AddressDetails = {
+  address: string;
+  category: string;
+  chain_id: number;
+  chain_name: string;
+  type: string;
+};
+
 const api = {
   zeta_mainnet: {
     evm: "https://zetachain-evm.blockpi.network/v1/rpc/public",
@@ -298,7 +306,7 @@ const fetchFactoryV3 = async (addresses: any, hre: HardhatRuntimeEnvironment, ne
 };
 
 const main = async (args: any, hre: HardhatRuntimeEnvironment) => {
-  const addresses: any = [];
+  let addresses: any = [];
 
   const n = hre.network.name;
   if (n === "zeta_testnet") {
@@ -321,6 +329,16 @@ const main = async (args: any, hre: HardhatRuntimeEnvironment) => {
   await fetchPauser(chains, addresses);
   await fetchFactoryV2(addresses, hre, network);
   await fetchFactoryV3(addresses, hre, network);
+
+  addresses = addresses.sort((a: AddressDetails, b: AddressDetails) => {
+    if (a.chain_id !== b.chain_id) {
+      return a.chain_id - b.chain_id;
+    } else if (a.type !== b.type) {
+      return a.type.localeCompare(b.type);
+    } else {
+      return a.address.localeCompare(b.address);
+    }
+  });
 
   console.log(JSON.stringify(addresses, null, 2));
 };


### PR DESCRIPTION
Right now address JSON generation is not deterministic. The two potential sources of non-determinism are:

* Order of properties in objects — this is taken care of eslint (properties are order alphabetically)
* Order of items in the array — this is actually not deterministic right now.

This doesn't affect the users of the package, but it does affect the development process: every time we generate addresses they may end up in different order and it's hard to tell if the content has changed (a big deal) or only the order (not a big deal).

This PR adds simple sorting so that every time addresses are generated they are generated deterministically.

I considered using canonical JSON libs instead, but they (understandably) don't sort arrays, because in arrays order is important.