### PR TITLE
chore: add remappings.txt

### DIFF
--- a/remappings.txt
+++ b/remappings.txt
@@ -1,0 +1,1 @@
+@openzeppelin/=node_modules/@openzeppelin/


### PR DESCRIPTION
Add a ` remappings.txt` for open-zeppelin dependencies

This allows:
- Running Slither tool using `slither [path]--solc-args "--allow-paths .,./node_modules" --solc-remaps @openzeppelin=node_modules/@openzeppelin`
- In the future, if we develop tests with Foundry, this files is also used to resolve dependencies