### PR TITLE
chore: add gas profiling in test

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -3,6 +3,7 @@ import "@nomicfoundation/hardhat-verify";
 import "@typechain/hardhat";
 import "tsconfig-paths/register";
 import "hardhat-abi-exporter";
+import "hardhat-gas-reporter";
 import "./tasks/addresses";
 
 import { getHardhatConfigNetworks } from "@zetachain/networks";


### PR DESCRIPTION
Include `hardhat-gas-reporter` in Hardhat config to print gas profiling upon test completion.

Close: https://github.com/zeta-chain/protocol-contracts/issues/168