### PR TITLE
ci: rename workflow jobs and run on push into `main`

### DIFF
--- a/.github/workflows/generated-files.yaml
+++ b/.github/workflows/generated-files.yaml
@@ -1,11 +1,20 @@
 name: Generated Files are Updated
+
 on:
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - "*"
+    types:
+      - synchronize
+      - opened
+      - reopened
+      - ready_for_review
 
 jobs:
-  build:
+  generate:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,12 +1,20 @@
 name: Lint TS/JS
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - "*"
+    types:
+      - synchronize
+      - opened
+      - reopened
+      - ready_for_review
 
 jobs:
-  build:
+  lint:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/publish-npm.yaml
+++ b/.github/workflows/publish-npm.yaml
@@ -5,7 +5,7 @@ on:
     types: [published]
 
 jobs:
-  build:
+  publish:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/semantic-pr.yaml
+++ b/.github/workflows/semantic-pr.yaml
@@ -1,13 +1,20 @@
 name: "Semantic PR"
+
 on:
-  pull_request_target:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - "*"
     types:
-      - opened
-      - edited
       - synchronize
+      - opened
+      - reopened
+      - ready_for_review
 
 jobs:
-  main:
+  semantic-pr:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,12 +1,20 @@
 name: Test
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - "*"
+    types:
+      - synchronize
+      - opened
+      - reopened
+      - ready_for_review
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
- Rename the workflow jobs so we can effectively tag required workflow in the CI
- Run CI on push into `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated GitHub Actions workflows to trigger on specific pull request events and pushes to the `main` branch.
  - Renamed job names for clarity: `build` to `generate`, `build` to `lint`, `build` to `publish`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->