### PR TITLE
fix: remove engines from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,9 +56,6 @@
     "typechain": "^8.1.0",
     "typescript": "^4.6.3"
   },
-  "engines": {
-    "node": ">=16 <17"
-  },
   "files": [
     "contracts",
     "abi",


### PR DESCRIPTION
I think this was added accidentally in #164, it results in this error when running with nodejs 20.x:

```
➜  protocol-contracts git:(main) yarn
yarn install v1.22.22
[1/5] Validating package.json...
error @zetachain/protocol-contracts@0.0.8: The engine "node" is incompatible with this module. Expected version ">=16 <17". Got "20.12.2"
error Found incompatible module.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed Node.js version constraints from the `package.json` file to enhance compatibility with different Node.js versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->