### PR TITLE
feat: add setAdditionalAddresses to enable dynamic addresses

### DIFF
--- a/lib/addresses.ts
+++ b/lib/addresses.ts
@@ -19,7 +19,7 @@ export const setAdditionalAddresses = (addresses: Address[]) => {
 }
 
 export const getAddress = (type: ParamType, network: ParamChainName, symbol?: ParamSymbol) => {
-  const networks = [...testnet, ...mainnet, ...additionalAddresses];
+  const networks = [...additionalAddresses, ...testnet, ...mainnet];
   let address;
   if (type !== "zrc20" && symbol) {
     throw new Error("Symbol is only supported when ParamType is zrc20");

--- a/lib/addresses.ts
+++ b/lib/addresses.ts
@@ -4,8 +4,22 @@ import mainnet from "../data/addresses.mainnet.json";
 import testnet from "../data/addresses.testnet.json";
 import { ParamChainName, ParamSymbol, ParamType } from "./types";
 
+interface Address {
+  address: string;
+  category: string;
+  chain_id: number;
+  chain_name: ParamChainName;
+  type: ParamType;
+}
+
+let additionalAddresses: Address[] = [];
+
+export const setAdditionalAddresses = (addresses: Address[]) => {
+  additionalAddresses = addresses;
+}
+
 export const getAddress = (type: ParamType, network: ParamChainName, symbol?: ParamSymbol) => {
-  const networks = [...testnet, ...mainnet];
+  const networks = [...testnet, ...mainnet, ...additionalAddresses];
   let address;
   if (type !== "zrc20" && symbol) {
     throw new Error("Symbol is only supported when ParamType is zrc20");

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -19,10 +19,12 @@ export type ParamChainName =
   | "btc_mainnet"
   | "btc_testnet"
   | "eth_mainnet"
+  | "eth_developnet"
   | "mumbai_testnet"
   | "sepolia_testnet"
   | "zeta_mainnet"
-  | "zeta_testnet";
+  | "zeta_testnet"
+  | "zeta_developnet";
 export type ParamType =
   | "connector"
   | "erc20Custody"


### PR DESCRIPTION
Allow downstream users to inject their own contract addresses if desired.

The contract addresses on localnet and developnet are not stable and must be pulled at runtime. This information will be retrieved from a json file via a network request. I had considered adding the logic here, but that doesn't seem quite right.

Related to https://github.com/zeta-chain/networks/pull/49

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded network options with the addition of `eth_developnet` and `zeta_developnet`.
  - Introduced new functionalities to manage additional addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->