### PR TITLE
chore: add fbac as codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*     @andresaiello @brewmaster012 @lumtis @charliemc0 @fadeev @skosito
+*     @andresaiello @brewmaster012 @lumtis @charliemc0 @fadeev @skosito @fbac


### PR DESCRIPTION
Add fbac as codeowner.
Fixes https://github.com/zeta-chain/protocol-contracts/issues/199