### PR TITLE
fix: build workflow and generate addresses

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,34 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - "*"
+    types:
+      - synchronize
+      - opened
+      - reopened
+      - ready_for_review
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install Dependencies
+        run: yarn install
+
+      - name: Build
+        run: yarn build

--- a/data/addresses.testnet.json
+++ b/data/addresses.testnet.json
@@ -198,6 +198,19 @@
     "type": "zrc20"
   },
   {
+    "address": "0x777915D031d1e8144c90D025C594b3b8Bf07a08d",
+    "asset": "",
+    "category": "omnichain",
+    "chain_id": 7001,
+    "chain_name": "zeta_testnet",
+    "coin_type": "gas",
+    "decimals": 18,
+    "description": "ZetaChain ZRC20 Amoy MATIC-amoy_testnet",
+    "foreign_chain_id": "80002",
+    "symbol": "MATIC.AMOY",
+    "type": "zrc20"
+  },
+  {
     "address": "0x7c8dDa80bbBE1254a7aACf3219EBe1481c6E01d7",
     "asset": "0x64544969ed7EBf5f083679233325356EbE738930",
     "category": "omnichain",
@@ -255,6 +268,48 @@
     "chain_id": 18332,
     "chain_name": "btc_testnet",
     "type": "tss"
+  },
+  {
+    "address": "0x60E6b70bC2761f878Ff992276612F67FbABC1761",
+    "category": "messaging",
+    "chain_id": 80002,
+    "chain_name": "amoy_testnet",
+    "type": "connector"
+  },
+  {
+    "address": "0xFDE448af6140a8702A1165c44A0895ebE24b0C02",
+    "category": "omnichain",
+    "chain_id": 80002,
+    "chain_name": "amoy_testnet",
+    "type": "erc20Custody"
+  },
+  {
+    "address": "0x55122f7590164Ac222504436943FAB17B62F5d7d",
+    "category": "messaging",
+    "chain_id": 80002,
+    "chain_name": "amoy_testnet",
+    "type": "pauser"
+  },
+  {
+    "address": "0x8531a5aB847ff5B22D855633C25ED1DA3255247e",
+    "category": "omnichain",
+    "chain_id": 80002,
+    "chain_name": "amoy_testnet",
+    "type": "tss"
+  },
+  {
+    "address": "0x55122f7590164Ac222504436943FAB17B62F5d7d",
+    "category": "omnichain",
+    "chain_id": 80002,
+    "chain_name": "amoy_testnet",
+    "type": "tssUpdater"
+  },
+  {
+    "address": "0x1432612E60cad487C857E7D38AFf57134916c902",
+    "category": "messaging",
+    "chain_id": 80002,
+    "chain_name": "amoy_testnet",
+    "type": "zetaToken"
   },
   {
     "address": "0x3963341dad121c9CD33046089395D66eBF20Fb03",

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -3,6 +3,7 @@ export type ParamSymbol =
   | "BTC.BTC"
   | "ETH.ETH"
   | "gETH"
+  | "MATIC.AMOY"
   | "sETH.SEPOLIA"
   | "tBNB"
   | "tBTC"
@@ -14,6 +15,7 @@ export type ParamSymbol =
   | "USDT.BSC"
   | "USDT.ETH";
 export type ParamChainName =
+  | "amoy_testnet"
   | "bsc_mainnet"
   | "bsc_testnet"
   | "btc_mainnet"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@uniswap/v2-core": "^1.0.1",
     "@uniswap/v2-periphery": "^1.1.0-beta.0",
     "@uniswap/v3-periphery": "^1.4.3",
-    "@zetachain/networks": "8.0.0-rc1",
+    "@zetachain/networks": "^8.0.0",
     "axios": "^1.6.5",
     "chai": "^4.3.6",
     "cpx": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@typechain/hardhat": "^6.1.2",
     "@types/chai": "^4.3.1",
     "@types/inquirer": "^8.2.1",
+    "@types/lodash": "^4.17.6",
     "@types/mocha": "^10.0.1",
     "@types/node": "^17.0.25",
     "@typescript-eslint/eslint-plugin": "^5.20.0",

--- a/tasks/addresses.ts
+++ b/tasks/addresses.ts
@@ -1,3 +1,4 @@
+import { ethers } from "ethers"; // Import ethers from hardhat
 import uniswapV2Router from "@uniswap/v2-periphery/build/IUniswapV2Router02.json";
 import SwapRouter from "@uniswap/v3-periphery/artifacts/contracts/SwapRouter.sol/SwapRouter.json";
 import { getEndpoints } from "@zetachain/networks";
@@ -134,12 +135,12 @@ const fetchForeignCoinsData = async (chains: any, addresses: any, network: Netwo
   }
 };
 
-const fetchAthensAddresses = async (addresses: any, hre: any, network: Network) => {
+const fetchAthensAddresses = async (addresses: any, hre: HardhatRuntimeEnvironment, network: Network) => {
   const chain_id = network === "zeta_mainnet" ? 7000 : 7001;
   const systemContract = addresses.find((a: any) => {
     return a.chain_name === network && a.type === "systemContract";
   })?.address;
-  const provider = new hre.ethers.providers.JsonRpcProvider(api[network].evm);
+  const provider = new ethers.providers.JsonRpcProvider(api[network].evm);
   const sc = SystemContract__factory.connect(systemContract, provider);
   const common = {
     category: "omnichain",
@@ -207,7 +208,7 @@ const fetchTSSUpdater = async (chains: any, addresses: any) => {
       if (erc20Custody) {
         if (["18332", "8332"].includes(chain.chain_id)) return;
         const rpc = getEndpoints("evm", chain.chain_name)[0]?.url;
-        const provider = new hre.ethers.providers.JsonRpcProvider(rpc);
+        const provider = new ethers.providers.JsonRpcProvider(rpc);
         const custody = ERC20Custody__factory.connect(erc20Custody, provider);
         return custody.TSSAddressUpdater().then((address: string) => {
           addresses.push({
@@ -232,7 +233,7 @@ const fetchPauser = async (chains: any, addresses: any) => {
       if (erc20Custody) {
         if (["18332", "8332", "7001", "7000"].includes(chain.chain_id)) return;
         const rpc = getEndpoints("evm", chain.chain_name)[0]?.url;
-        const provider = new hre.ethers.providers.JsonRpcProvider(rpc);
+        const provider = new ethers.providers.JsonRpcProvider(rpc);
         const connector = ZetaConnectorBase__factory.connect(erc20Custody, provider);
         return connector.pauserAddress().then((address: string) => {
           addresses.push({
@@ -253,8 +254,8 @@ const fetchFactoryV2 = async (addresses: any, hre: HardhatRuntimeEnvironment, ne
 
   for (const router of routers) {
     const rpc = getEndpoints("evm", router.chain_name)[0]?.url;
-    const provider = new hre.ethers.providers.JsonRpcProvider(rpc);
-    const routerContract = new hre.ethers.Contract(router.address, uniswapV2Router.abi, provider);
+    const provider = new ethers.providers.JsonRpcProvider(rpc);
+    const routerContract = new ethers.Contract(router.address, uniswapV2Router.abi, provider);
 
     try {
       const wethAddress = await routerContract.WETH();
@@ -289,8 +290,8 @@ const fetchFactoryV3 = async (addresses: any, hre: HardhatRuntimeEnvironment, ne
 
   for (const router of routers) {
     const rpc = getEndpoints("evm", router.chain_name)[0]?.url;
-    const provider = new hre.ethers.providers.JsonRpcProvider(rpc);
-    const routerContract = new hre.ethers.Contract(router.address, SwapRouter.abi, provider);
+    const provider = new ethers.providers.JsonRpcProvider(rpc);
+    const routerContract = new ethers.Contract(router.address, SwapRouter.abi, provider);
 
     try {
       const wethAddress = await routerContract.WETH9();

--- a/tasks/addresses.ts
+++ b/tasks/addresses.ts
@@ -1,8 +1,8 @@
-import { ethers } from "ethers"; // Import ethers from hardhat
 import uniswapV2Router from "@uniswap/v2-periphery/build/IUniswapV2Router02.json";
 import SwapRouter from "@uniswap/v3-periphery/artifacts/contracts/SwapRouter.sol/SwapRouter.json";
 import { getEndpoints } from "@zetachain/networks";
 import axios, { AxiosResponse } from "axios";
+import { ethers } from "ethers"; // Import ethers from hardhat
 import { task } from "hardhat/config";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 import { isEqual } from "lodash";

--- a/tasks/addresses.ts
+++ b/tasks/addresses.ts
@@ -2,7 +2,7 @@ import uniswapV2Router from "@uniswap/v2-periphery/build/IUniswapV2Router02.json
 import SwapRouter from "@uniswap/v3-periphery/artifacts/contracts/SwapRouter.sol/SwapRouter.json";
 import { getEndpoints } from "@zetachain/networks";
 import axios, { AxiosResponse } from "axios";
-import { ethers } from "ethers"; // Import ethers from hardhat
+import { ethers } from "ethers";
 import { task } from "hardhat/config";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 import { isEqual } from "lodash";

--- a/tasks/addresses.ts
+++ b/tasks/addresses.ts
@@ -135,7 +135,7 @@ const fetchForeignCoinsData = async (chains: any, addresses: any, network: Netwo
   }
 };
 
-const fetchAthensAddresses = async (addresses: any, hre: HardhatRuntimeEnvironment, network: Network) => {
+const fetchAthensAddresses = async (addresses: any, network: Network) => {
   const chain_id = network === "zeta_mainnet" ? 7000 : 7001;
   const systemContract = addresses.find((a: any) => {
     return a.chain_name === network && a.type === "systemContract";
@@ -249,7 +249,7 @@ const fetchPauser = async (chains: any, addresses: any) => {
   );
 };
 
-const fetchFactoryV2 = async (addresses: any, hre: HardhatRuntimeEnvironment, network: Network) => {
+const fetchFactoryV2 = async (addresses: any, network: Network) => {
   const routers = addresses.filter((a: any) => a.type === "uniswapV2Router02");
 
   for (const router of routers) {
@@ -285,7 +285,7 @@ const fetchFactoryV2 = async (addresses: any, hre: HardhatRuntimeEnvironment, ne
   }
 };
 
-const fetchFactoryV3 = async (addresses: any, hre: HardhatRuntimeEnvironment, network: Network) => {
+const fetchFactoryV3 = async (addresses: any, network: Network) => {
   const routers = addresses.filter((a: any) => a.type === "uniswapV3Router");
 
   for (const router of routers) {
@@ -340,12 +340,12 @@ const main = async (args: any, hre: HardhatRuntimeEnvironment) => {
   await fetchTssData(chains, addresses, network);
   await fetchSystemContract(addresses, network);
   await fetchForeignCoinsData(chains, addresses, network);
-  await fetchAthensAddresses(addresses, hre, network);
+  await fetchAthensAddresses(addresses, network);
   await fetchChainSpecificAddresses(chains, addresses, network);
   await fetchTSSUpdater(chains, addresses);
   await fetchPauser(chains, addresses);
-  await fetchFactoryV2(addresses, hre, network);
-  await fetchFactoryV3(addresses, hre, network);
+  await fetchFactoryV2(addresses, network);
+  await fetchFactoryV3(addresses, network);
 
   addresses = addresses.sort((a: AddressDetails, b: AddressDetails) => {
     if (a.chain_id !== b.chain_id) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,6 @@
     "noImplicitAny": true,
     "outDir": "dist",
     "paths": {
-      "@openzeppelin/*": ["node_modules/@openzeppelin/*"],
       "@typechain-types": ["typechain-types"]
     },
     "resolveJsonModule": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
     "noImplicitAny": true,
     "outDir": "dist",
     "paths": {
-      "@typechain-types": ["typechain-types"]
+      "@typechain-types": ["typechain-types"],
+      "@openzeppelin/*": ["node_modules/@openzeppelin/*"]
     },
     "resolveJsonModule": true,
     "skipLibCheck": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,8 +9,8 @@
     "noImplicitAny": true,
     "outDir": "dist",
     "paths": {
-      "@typechain-types": ["typechain-types"],
-      "@openzeppelin/*": ["node_modules/@openzeppelin/*"]
+      "@openzeppelin/*": ["node_modules/@openzeppelin/*"],
+      "@typechain-types": ["typechain-types"]
     },
     "resolveJsonModule": true,
     "skipLibCheck": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1910,6 +1910,11 @@
     "@types/level-errors" "*"
     "@types/node" "*"
 
+"@types/lodash@^4.17.6":
+  version "4.17.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.17.6.tgz#193ced6a40c8006cfc1ca3f4553444fb38f0e543"
+  integrity sha512-OpXEVoCKSS3lQqjx9GGGOapBeuW5eUboYHRlHP9urXPX25IKZ6AnP5ZRxtVf63iieUbsHxLn8NQ5Nlftc6yzAA==
+
 "@types/lru-cache@5.1.1", "@types/lru-cache@^5.1.0":
   version "5.1.1"
   resolved "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-5.1.1.tgz"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2169,10 +2169,10 @@
     "@uniswap/v3-core" "1.0.0"
     base64-sol "1.0.1"
 
-"@zetachain/networks@8.0.0-rc1":
-  version "8.0.0-rc1"
-  resolved "https://registry.yarnpkg.com/@zetachain/networks/-/networks-8.0.0-rc1.tgz#3ad8891a7e2120509ef560720c6fa573a0a0b73f"
-  integrity sha512-rw09aariRcNItoNYClHq6Gm2IUNoBOFHOO3VHNyN7krapbY0Jy4HCQQj8iq7oNWZyNfwDIxIqkiQURPvIfpsMw==
+"@zetachain/networks@^8.0.0":
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/@zetachain/networks/-/networks-8.0.0.tgz#3e838bb6b14e4a8d381f95b4cbc2f1172e851e4e"
+  integrity sha512-I0HhH5qOGW0Jkjq5o5Mi6qGls6ycHnhWjc+r+Ud8u8YW+HU4lEUn4gvulxj+ccHKj3nV/0gEsmNrWRY9ct49nQ==
   dependencies:
     dotenv "^16.1.4"
 


### PR DESCRIPTION
* added a build workflow to ensure that the code builds before it gets merged
* updated Amoy contract addresses

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added new address entries for `amoy_testnet` and `zeta_testnet` chains, enhancing support for various categories like messaging, omnichain, and connector.
  - Addresses support types such as `tss`, `erc20Custody`, `pauser`, `tssUpdater`, and `zetaToken`, increasing functionality and integration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->