### PR TITLE
ci: add slither static analysis

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -1,4 +1,4 @@
-name: Test
+name: Coverage
 
 on:
   push:

--- a/.github/workflows/slither.yaml
+++ b/.github/workflows/slither.yaml
@@ -1,0 +1,50 @@
+name: Slither
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - "*"
+    types:
+      - synchronize
+      - opened
+      - reopened
+      - ready_for_review
+
+jobs:
+  slither:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: "18"
+
+      - name: Install Dependencies
+        run: yarn install
+
+      - name: Compile contracts
+        run: yarn compile
+
+      - name: Run Slither
+        uses: crytic/slither-action@main
+        id: slither
+        continue-on-error: true
+        with:
+          sarif: results.sarifs
+          node-version: "18"
+          fail-on: none
+
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: ${{ steps.slither.outputs.sarif }}

--- a/slither.config.json
+++ b/slither.config.json
@@ -1,0 +1,7 @@
+{
+  "detectors_to_exclude": "",
+  "compile_force_framework": "hardhat",
+  "hardhat_ignore_compile": true,
+  "npx_disable": true,
+  "filter_paths": "artifacts,cache,data,dist,docs,lib,node_modules,pkg,scripts,tasks,test,testing,typechain-types"
+}


### PR DESCRIPTION
- Fix a typo in the Coverage workflow.
- Add Slither to the CI.
- Slither can also be used as a CLI tool running `slither .` in the root of the repository, it will use the provided slither.config.json.
- Fixes https://github.com/zeta-chain/protocol-contracts/issues/165

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new GitHub Actions workflow named "Slither" for smart contract analysis.
  - Added `slither.config.json` for configuring project-specific analysis settings.

- **Chores**
  - Renamed the "Test" workflow to "Coverage" for better clarity in GitHub Actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->