### PR TITLE
ci: slither ignore foundry compilation

### DIFF
--- a/.github/workflows/slither.yaml
+++ b/.github/workflows/slither.yaml
@@ -33,19 +33,19 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
-      
-      - name: Install Dependencies
+
+      - name: Install dependencies
         run: yarn install
 
-      - name: Compile contracts
-        run: yarn compile
+      - name: Build project
+        run: yarn build
 
       - name: Run Slither
         uses: crytic/slither-action@main
         id: slither
         continue-on-error: true
         with:
-          sarif: results.sarifs
+          sarif: results.sarif
           node-version: "18"
           fail-on: none
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: "18"
+          node-version: "20"
           registry-url: "https://registry.npmjs.org"
 
       - name: Install Foundry
@@ -34,6 +34,9 @@ jobs:
 
       - name: Install Dependencies
         run: yarn install
+
+      - name: Build project
+        run: yarn build
 
       - name: Test (hardhat)
         run: yarn test
@@ -43,6 +46,3 @@ jobs:
 
       - name: Test v2 (forge)
         run: yarn test:forge
-
-      
-    

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,9 +40,3 @@ jobs:
 
       - name: Test (hardhat)
         run: yarn test
-
-      - name: Test v2 (hardhat)
-        run: yarn test:prototypes
-
-      - name: Test v2 (forge)
-        run: yarn test:forge

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "prepublishOnly": "yarn build",
     "test": "npx hardhat test",
     "test:forge": "forge test -vvv",
-    "test:prototypes": "npx hardhat test test/prototypes/*",
+    "test:prototypes": "yarn compile && npx hardhat test test/prototypes/*",
     "tsc:watch": "npx tsc --watch",
     "worker": "npx hardhat run scripts/worker.ts --network localhost"
   },

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "prepublishOnly": "yarn build",
     "test": "npx hardhat test",
     "test:forge": "forge test -vvv",
-    "test:prototypes": "yarn compile && npx hardhat test test/prototypes/*",
+    "test:prototypes": "npx hardhat test test/prototypes/*",
     "tsc:watch": "npx tsc --watch",
     "worker": "npx hardhat run scripts/worker.ts --network localhost"
   },

--- a/slither.config.json
+++ b/slither.config.json
@@ -1,5 +1,4 @@
 {
-  "compile_force_framework": "foundry",
   "detectors_to_exclude": "",
   "filter_paths": "forge-std,artifacts,cache,data,dist,docs,lib,node_modules,pkg,scripts,tasks,test,testing,typechain-types"
 }

--- a/slither.config.json
+++ b/slither.config.json
@@ -1,7 +1,5 @@
 {
-  "compile_force_framework": "hardhat",
+  "compile_force_framework": "foundry",
   "detectors_to_exclude": "",
-  "filter_paths": "artifacts,cache,data,dist,docs,lib,node_modules,pkg,scripts,tasks,test,testing,typechain-types",
-  "hardhat_ignore_compile": true,
-  "npx_disable": true
+  "filter_paths": "forge-std,artifacts,cache,data,dist,docs,lib,node_modules,pkg,scripts,tasks,test,testing,typechain-types"
 }


### PR DESCRIPTION
Ignore foundry compilation when running slither as a CLI and in CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated GitHub workflows to use `yarn build` instead of `yarn compile` for consistency in build processes.
  - Added configurations to improve workflow execution for Slither and testing.
- **Refactor**
  - Modified `package.json` scripts to streamline testing by removing redundant compile steps.
- **Configuration**
  - Added and adjusted Mocha timeout settings to enhance test reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->