### PR TITLE
ci: update codecov to use Foundry

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -37,3 +37,4 @@ jobs:
         uses: codecov/codecov-action@v4.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          files: lcov.info

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -33,6 +33,11 @@ jobs:
       - name: Test with coverage
         run: yarn coverage || true
     
+      - name: Verify lcov.info presence
+        run: |
+          echo "Listing files in the root directory to verify lcov.info presence"
+          ls -la
+
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4.0.1
         with:

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -27,11 +27,14 @@ jobs:
           node-version: "18"
           registry-url: "https://registry.npmjs.org"
 
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+
       - name: Install Dependencies
         run: yarn install
 
       - name: Test with coverage
-        run: yarn coverage || true
+        run: yarn coverage
     
       - name: Verify lcov.info presence
         run: |

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -35,11 +35,6 @@ jobs:
 
       - name: Test with coverage
         run: yarn coverage
-    
-      - name: Verify lcov.info presence
-        run: |
-          echo "Listing files in the root directory to verify lcov.info presence"
-          ls -la
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4.0.1

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ tsconfig.tsbuildinfo
 # Coverage
 coverage
 coverage.json
+lcov.info
 
 # Slither
 scripts/slither-results/*

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,5 +1,5 @@
 [profile.default]
-src = 'contracts'
+src = 'contracts/prototypes'
 out = 'out'
 libs = ['node_modules', 'lib']
 test = 'testFoundry'

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
   "scripts": {
     "build": "yarn compile && npx del-cli dist abi && npx tsc || true && npx del-cli './dist/typechain-types/**/*.js' && npx cpx './data/**/*' dist/data && npx cpx './artifacts/contracts/**/*' ./abi && npx del-cli './abi/**/*.dbg.json'",
     "compile": "npx hardhat compile --force",
-    "coverage": "npx hardhat coverage --temp ./coverage-artifacts",
+    "coverage": "forge clean && forge coverage --report lcov",
     "docs": "forge doc",
     "generate": "yarn compile && ./scripts/generate_go.sh || true && ./scripts/generate_addresses.sh && yarn lint:fix",
     "lint": "npx eslint . --ext .js,.ts --ignore-pattern lib/",


### PR DESCRIPTION
Update `yarn coverage` to use `forge coverage` instead of Hardhat