### PR TITLE
chore: add gitattributes to mark generated directories

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Mark all files in the generated directory as generated
+pkg/* linguist-generated
+typechain-types/* linguist-generated

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,3 @@
-# Mark all files in the generated directory as generated
+# Mark all files in the directories as generated
 pkg/* linguist-generated
 typechain-types/* linguist-generated


### PR DESCRIPTION
Allow to mark the directories for generated files and, in theory, should hide these by default in reviews

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Added directives to mark all files in the `pkg` and `typechain-types` directories as generated for better file management and recognition by Linguist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->