### PR TITLE
feat: Remove outdated chains on protocol contracts types

### DIFF
--- a/lib/address.tools.ts
+++ b/lib/address.tools.ts
@@ -32,23 +32,17 @@ export declare type ZetaZEVMAddress =
 
 export declare type ZetaProtocolTestNetwork =
   | "amoy_testnet"
-  | "baobab_testnet"
   | "bsc_testnet"
   | "btc_testnet"
-  | "goerli_testnet"
-  | "mumbai_testnet"
   | "sepolia_testnet"
   | "zeta_testnet";
 
 export const zetaProtocolTestNetworks: ZetaProtocolTestNetwork[] = [
-  "baobab_testnet",
+  "amoy_testnet",
   "bsc_testnet",
   "btc_testnet",
-  "goerli_testnet",
   "sepolia_testnet",
-  "mumbai_testnet",
   "zeta_testnet",
-  "amoy_testnet",
 ];
 
 export declare type NonZetaAddress =
@@ -66,23 +60,35 @@ export const nonZetaAddress: NonZetaAddress[] = [
   "weth9",
 ];
 
-export declare type ZetaProtocolMainNetwork = "bsc_mainnet" | "eth_mainnet" | "zeta_mainnet" | "polygon_mainnet";
-export const zetaProtocolMainNetworks: ZetaProtocolMainNetwork[] = ["eth_mainnet", "bsc_mainnet", "polygon_mainnet", "zeta_mainnet"];
+export declare type ZetaProtocolMainNetwork =
+  | "bsc_mainnet"
+  | "btc_mainnet"
+  | "eth_mainnet"
+  | "polygon_mainnet"
+  | "zeta_mainnet";
+
+export const zetaProtocolMainNetworks: ZetaProtocolMainNetwork[] = [
+  "bsc_mainnet",
+  "btc_mainnet",
+  "eth_mainnet",
+  "polygon_mainnet",
+  "zeta_mainnet",
+];
 
 export declare type ZetaProtocolNetwork = ZetaProtocolMainNetwork | ZetaProtocolTestNetwork;
 export const zetaProtocolNetworks: ZetaProtocolNetwork[] = [...zetaProtocolTestNetworks, ...zetaProtocolMainNetworks];
 
-export declare type ZetaProtocolEnviroment = "mainnet" | "testnet";
+export declare type ZetaProtocolEnvironment = "mainnet" | "testnet";
 
 export const isProtocolNetworkName = (str: string): str is ZetaProtocolNetwork =>
   zetaProtocolNetworks.includes(str as ZetaProtocolNetwork);
 
-export const isTestnetNetwork = (network: ZetaProtocolTestNetwork): boolean => {
-  return zetaProtocolTestNetworks.includes(network);
+export const isTestnetNetwork = (network: string): boolean => {
+  return zetaProtocolTestNetworks.includes(network as ZetaProtocolTestNetwork);
 };
 
-export const isMainnetNetwork = (network: ZetaProtocolTestNetwork): boolean => {
-  return false;
+export const isMainnetNetwork = (network: string): boolean => {
+  return zetaProtocolMainNetworks.includes(network as ZetaProtocolMainNetwork);
 };
 
 export const getZRC20Address = (network: ZetaProtocolNetwork): string => {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,4 +1,41 @@
-export type ParamSymbol = "USDC.BSC" | "USDC.ETH" | "BTC.BTC" | "PEPE.ETH" | "BNB.BSC" | "SHIB.ETH" | "USDT.ETH" | "USDT.BSC" | "POL.POLYGON" | "DAI.ETH" | "ETH.ETH" | "sETH.SEPOLIA" | "USDC" | "gETH" | "tMATIC" | "tBTC" | "MATIC.AMOY" | "USDC.SEPOLIA" | "tBNB";
-export type ParamChainName = "eth_mainnet" | "bsc_mainnet" | "polygon_mainnet" | "zeta_mainnet" | "btc_mainnet" | "bsc_testnet" | "zeta_testnet" | "btc_testnet" | "amoy_testnet" | "sepolia_testnet";
-export type ParamType = "connector" | "erc20Custody" | "pauser" | "tss" | "tssUpdater" | "uniswapV2Factory" | "uniswapV2Router02" | "uniswapV3Factory" | "uniswapV3Router" | "weth9" | "zetaToken" | "fungibleModule" | "systemContract" | "zrc20" | "zetaTokenConsumerUniV3";
+import { ZetaProtocolNetwork } from "./address.tools";
 
+export type ParamSymbol =
+  | "BNB.BSC"
+  | "BTC.BTC"
+  | "DAI.ETH"
+  | "ETH.ETH"
+  | "gETH"
+  | "MATIC.AMOY"
+  | "PEPE.ETH"
+  | "POL.POLYGON"
+  | "sETH.SEPOLIA"
+  | "SHIB.ETH"
+  | "tBNB"
+  | "tBTC"
+  | "tMATIC"
+  | "USDC.BSC"
+  | "USDC.ETH"
+  | "USDC.SEPOLIA"
+  | "USDC"
+  | "USDT.BSC"
+  | "USDT.ETH";
+
+export type ParamChainName = ZetaProtocolNetwork;
+
+export type ParamType =
+  | "connector"
+  | "erc20Custody"
+  | "fungibleModule"
+  | "pauser"
+  | "systemContract"
+  | "tss"
+  | "tssUpdater"
+  | "uniswapV2Factory"
+  | "uniswapV2Router02"
+  | "uniswapV3Factory"
+  | "uniswapV3Router"
+  | "weth9"
+  | "zetaToken"
+  | "zetaTokenConsumerUniV3"
+  | "zrc20";


### PR DESCRIPTION
### Summary
- Remove old chains

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated types and constants for Zeta Protocol's network configurations, enhancing clarity and maintainability.
	- Added "btc_mainnet" to the main networks available, expanding options for users.
	
- **Bug Fixes**
	- Corrected the spelling of "Enviroment" to "Environment" for improved accuracy.

- **Refactor**
	- Improved the structure and readability of type definitions, making them easier to understand and manage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->