### PR TITLE
ci: action for manual file generation

### DIFF
--- a/.github/workflows/generate-manual.yaml
+++ b/.github/workflows/generate-manual.yaml
@@ -7,6 +7,10 @@ on:
         description: 'The branch to create the pull request into'
         required: true
         default: 'main'
+      custom_branch_name:
+        description: 'The custom branch name for generated code changes'
+        required: true
+        default: 'update-generated-files'
 
 defaults:
   run:
@@ -58,17 +62,17 @@ jobs:
             echo "::set-output name=changes::true"
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
-            git checkout -b update-generated-files
+            git checkout -b ${{ github.event.inputs.custom_branch_name }}
             git add pkg types
-            git commit -m "Update generated Go files"
-            git push origin update-generated-files
+            git commit -m "ci: generate files"
+            git push origin ${{ github.event.inputs.custom_branch_name }}
 
       - name: Create Pull Request
         if: steps.check_changes.outputs.changes == 'true'
         uses: peter-evans/create-pull-request@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          branch: update-generated-files
+          branch: ${{ github.event.inputs.custom_branch_name }}
           base: ${{ github.event.inputs.branch }}
           title: "ci: generate files"
           body: |

--- a/.github/workflows/generate-manual.yaml
+++ b/.github/workflows/generate-manual.yaml
@@ -1,0 +1,76 @@
+name: Manually Generate Files
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'The branch to create the pull request into'
+        required: true
+        default: 'main'
+
+defaults:
+  run:
+    working-directory: ./v2
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.branch }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "21.1.0"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y jq unzip
+          yarn install
+          forge soldeer update
+
+      - name: Install specific version of aibgen
+        run: |
+          wget https://gethstore.blob.core.windows.net/builds/geth-alltools-linux-amd64-1.11.5-a38f4108.tar.gz
+          tar -zxvf geth-alltools-linux-amd64-1.11.5-a38f4108.tar.gz
+          sudo mv geth-alltools-linux-amd64-1.11.5-a38f4108/abigen /usr/local/bin/
+
+      - name: Generate Go packages and types
+        run: |
+          yarn generate
+
+      - name: Check for changes
+        id: check_changes
+        run: |
+          if git diff --exit-code --ignore-space-change --ignore-all-space --ignore-cr-at-eol -- pkg types; then
+            echo "Generated Go files are up-to-date."
+            echo "::set-output name=changes::false"
+          else
+            echo "Generated files are not up-to-date. Creating a PR."
+            echo "::set-output name=changes::true"
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git checkout -b update-generated-files
+            git add pkg types
+            git commit -m "Update generated Go files"
+            git push origin update-generated-files
+
+      - name: Create Pull Request
+        if: steps.check_changes.outputs.changes == 'true'
+        uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: update-generated-files
+          base: ${{ github.event.inputs.branch }}
+          title: "ci: generate files"
+          body: |
+            This PR updates the auto-generated files with `yarn generate`. Please review the changes.
+          labels: ["CI"]


### PR DESCRIPTION
Given `yarn generate` output depends on machine setup,  this action allow to easily create a PR to make the file generation depending on the setup in the CI.

Creating it as I'm running into an issue where I can't find reason for different input (same Forge, solc, and abigen version as CI but the generated contract binary is slightly different)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new GitHub Actions workflow for manual file generation, allowing users to trigger the process and specify branches for pull requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->