### PR TITLE
chore(v20): update gatewayEVM and ERC20Custody salts

### DIFF
--- a/v2/scripts/deploy/deterministic/DeployERC20Custody.s.sol
+++ b/v2/scripts/deploy/deterministic/DeployERC20Custody.s.sol
@@ -14,8 +14,8 @@ contract DeployERC20Custody is Script {
         address expectedImplAddress;
         address expectedProxyAddress;
 
-        bytes32 implSalt = keccak256("ERC20Custody");
-        bytes32 proxySalt = keccak256("ERC20CustodyProxy");
+        bytes32 implSalt = keccak256("ERC20Custody-2");
+        bytes32 proxySalt = keccak256("ERC20CustodyProxy-2");
 
         vm.startBroadcast();
 

--- a/v2/scripts/deploy/deterministic/DeployGatewayEVM.s.sol
+++ b/v2/scripts/deploy/deterministic/DeployGatewayEVM.s.sol
@@ -15,8 +15,8 @@ contract DeployGatewayEVM is Script {
         address expectedImplAddress;
         address expectedProxyAddress;
 
-        bytes32 implSalt = keccak256("GatewayEVM");
-        bytes32 proxySalt = keccak256("GatewayEVMProxy");
+        bytes32 implSalt = keccak256("GatewayEVM-2");
+        bytes32 proxySalt = keccak256("GatewayEVMProxy-2");
 
         vm.startBroadcast();
 


### PR DESCRIPTION
Backport the change mentioned in https://github.com/zeta-chain/protocol-contracts/pull/413#discussion_r1814859207