### PR TITLE
ci: publish release notes to Discord

### DIFF
--- a/.github/workflows/release-to-discord.yaml
+++ b/.github/workflows/release-to-discord.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Github Releases To Discord
         uses: SethCohen/github-releases-to-discord@v1.16.2
         with:

--- a/.github/workflows/release-to-discord.yaml
+++ b/.github/workflows/release-to-discord.yaml
@@ -1,0 +1,20 @@
+on:
+  release:
+    types: [published]
+
+jobs:
+  github-releases-to-discord:
+    if: "! contains(github.event.release.tag_name, '-')"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Github Releases To Discord
+        uses: SethCohen/github-releases-to-discord@v1.16.2
+        with:
+          webhook_url: ${{ secrets.WEBHOOK_URL }}
+          color: "2105893"
+          username: "New Release: Protocol Contracts"
+          max_description: "4096"
+          reduce_headings: true
+          avatar_url: "https://raw.githubusercontent.com/zeta-chain/docs/refs/heads/main/public/img/icons/zetachain/square/white-on-green.png"


### PR DESCRIPTION
Automatically publish release notes to Discord like so:

<img width="751" alt="Screenshot 2024-11-01 at 15 32 42" src="https://github.com/user-attachments/assets/ac0e9cb3-7623-4eeb-bf5b-86a8b144f4f3">

Requires setting `WEBHOOK_URL` in the repo settings (can't do it myself, don't have permissions).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an automated workflow to post release notifications to a Discord channel upon publishing a release.
- **Chores**
	- Added configuration for the new GitHub Actions workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->