### PR TITLE
chore: update codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*     @andresaiello @brewmaster012 @lumtis @charliemc0 @fadeev @skosito @fbac
+*     @andresaiello @brewmaster012 @lumtis @charliemc0 @fadeev @skosito

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*     @andresaiello @brewmaster012 @lumtis @charliemc0 @fadeev @skosito
+*     @zeta-chain/devex @zeta-chain/protocol-engineering


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated the code ownership list to reflect new responsibilities, now including `@zeta-chain/devex` and `@zeta-chain/protocol-engineering`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->