### PR TITLE
chore: more permissive solidity pragma

### DIFF
--- a/contracts/Errors.sol
+++ b/contracts/Errors.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.26;
+pragma solidity ^0.8.26;
 
 /// @title INotSupportedMethods
 /// @notice Interface for contracts that with non supported methods.

--- a/contracts/Revert.sol
+++ b/contracts/Revert.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.26;
+pragma solidity ^0.8.26;
 
 /// @notice Struct containing revert options
 /// @param revertAddress Address to receive revert.

--- a/contracts/evm/ERC20Custody.sol
+++ b/contracts/evm/ERC20Custody.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.26;
+pragma solidity ^0.8.26;
 
 import { IERC20Custody } from "./interfaces/IERC20Custody.sol";
 import { IGatewayEVM, MessageContext } from "./interfaces/IGatewayEVM.sol";

--- a/contracts/evm/GatewayEVM.sol
+++ b/contracts/evm/GatewayEVM.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.26;
+pragma solidity ^0.8.26;
 
 import { INotSupportedMethods } from "../../contracts/Errors.sol";
 import { RevertContext, RevertOptions, Revertable } from "../../contracts/Revert.sol";

--- a/contracts/evm/ZetaConnectorBase.sol
+++ b/contracts/evm/ZetaConnectorBase.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.26;
+pragma solidity ^0.8.26;
 
 import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";

--- a/contracts/evm/ZetaConnectorNative.sol
+++ b/contracts/evm/ZetaConnectorNative.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.26;
+pragma solidity ^0.8.26;
 
 import "./ZetaConnectorBase.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/contracts/evm/ZetaConnectorNonNative.sol
+++ b/contracts/evm/ZetaConnectorNonNative.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.26;
+pragma solidity ^0.8.26;
 
 import "./ZetaConnectorBase.sol";
 import "./interfaces/IZetaNonEthNew.sol";

--- a/contracts/evm/interfaces/IERC20Custody.sol
+++ b/contracts/evm/interfaces/IERC20Custody.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.26;
+pragma solidity ^0.8.26;
 
 import { RevertContext } from "../../../contracts/Revert.sol";
 

--- a/contracts/evm/interfaces/IGatewayEVM.sol
+++ b/contracts/evm/interfaces/IGatewayEVM.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.26;
+pragma solidity ^0.8.26;
 
 import "../../../contracts/Revert.sol";
 

--- a/contracts/evm/interfaces/IZetaConnector.sol
+++ b/contracts/evm/interfaces/IZetaConnector.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.26;
+pragma solidity ^0.8.26;
 
 import { RevertContext } from "../../../contracts/Revert.sol";
 

--- a/contracts/evm/interfaces/IZetaNonEthNew.sol
+++ b/contracts/evm/interfaces/IZetaNonEthNew.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.26;
+pragma solidity ^0.8.26;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 

--- a/contracts/zevm/GatewayZEVM.sol
+++ b/contracts/zevm/GatewayZEVM.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.26;
+pragma solidity ^0.8.26;
 
 import { CallOptions, IGatewayZEVM } from "./interfaces/IGatewayZEVM.sol";
 

--- a/contracts/zevm/SystemContract.sol
+++ b/contracts/zevm/SystemContract.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.26;
+pragma solidity ^0.8.26;
 
 import "./interfaces/IZRC20.sol";
 import "./interfaces/UniversalContract.sol";

--- a/contracts/zevm/ZRC20.sol
+++ b/contracts/zevm/ZRC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.26;
+pragma solidity ^0.8.26;
 
 import "../../contracts/zevm/interfaces/ISystem.sol";
 import "../../contracts/zevm/interfaces/IZRC20.sol";

--- a/contracts/zevm/interfaces/IGatewayZEVM.sol
+++ b/contracts/zevm/interfaces/IGatewayZEVM.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.26;
+pragma solidity ^0.8.26;
 
 import "../../../contracts/Revert.sol";
 import "./UniversalContract.sol";

--- a/contracts/zevm/interfaces/ISystem.sol
+++ b/contracts/zevm/interfaces/ISystem.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.26;
+pragma solidity ^0.8.26;
 
 /// @title ISystem
 /// @notice Interface for the System contract.

--- a/contracts/zevm/interfaces/IWZETA.sol
+++ b/contracts/zevm/interfaces/IWZETA.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.26;
+pragma solidity ^0.8.26;
 
 /// @title IWETH9
 /// @notice Interface for the Weth9 contract.

--- a/contracts/zevm/interfaces/IZRC20.sol
+++ b/contracts/zevm/interfaces/IZRC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.26;
+pragma solidity ^0.8.26;
 
 /// @title IZRC20
 /// @notice Interface for the ZRC20 token contract.

--- a/contracts/zevm/interfaces/UniversalContract.sol
+++ b/contracts/zevm/interfaces/UniversalContract.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.26;
+pragma solidity ^0.8.26;
 
 import { RevertContext } from "../../../contracts/Revert.sol";
 

--- a/scripts/deploy/DeployZRC20.s.sol
+++ b/scripts/deploy/DeployZRC20.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.26;
+pragma solidity ^0.8.26;
 
 import "forge-std/Script.sol";
 import "../../contracts/zevm/ZRC20.sol";

--- a/scripts/deploy/deterministic/DeployERC20Custody.s.sol
+++ b/scripts/deploy/deterministic/DeployERC20Custody.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.26;
+pragma solidity ^0.8.26;
 
 import "forge-std/Script.sol";
 import "contracts/evm/ERC20Custody.sol";

--- a/scripts/deploy/deterministic/DeployERC20CustodyImplementation.s.sol
+++ b/scripts/deploy/deterministic/DeployERC20CustodyImplementation.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.26;
+pragma solidity ^0.8.26;
 
 import "forge-std/Script.sol";
 import "contracts/evm/ERC20Custody.sol";

--- a/scripts/deploy/deterministic/DeployGatewayEVM.s.sol
+++ b/scripts/deploy/deterministic/DeployGatewayEVM.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.26;
+pragma solidity ^0.8.26;
 
 import "forge-std/Script.sol";
 import "contracts/evm/GatewayEVM.sol";

--- a/scripts/deploy/deterministic/DeployGatewayEVMImplementation.s.sol
+++ b/scripts/deploy/deterministic/DeployGatewayEVMImplementation.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.26;
+pragma solidity ^0.8.26;
 
 import "forge-std/Script.sol";
 import "contracts/evm/GatewayEVM.sol";

--- a/scripts/deploy/deterministic/DeployGatewayZEVM.s.sol
+++ b/scripts/deploy/deterministic/DeployGatewayZEVM.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.26;
+pragma solidity ^0.8.26;
 
 import "forge-std/Script.sol";
 import "contracts/zevm/GatewayZEVM.sol";

--- a/scripts/deploy/deterministic/DeployGatewayZEVMImplementation.s.sol
+++ b/scripts/deploy/deterministic/DeployGatewayZEVMImplementation.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.26;
+pragma solidity ^0.8.26;
 
 import "forge-std/Script.sol";
 import "contracts/zevm/GatewayZEVM.sol";

--- a/scripts/deploy/deterministic/DeployTestERC20.s.sol
+++ b/scripts/deploy/deterministic/DeployTestERC20.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.26;
+pragma solidity ^0.8.26;
 
 import "forge-std/Script.sol";
 import "test/utils/TestERC20.sol";

--- a/scripts/deploy/deterministic/DeployZetaConnectorNonNative.s.sol
+++ b/scripts/deploy/deterministic/DeployZetaConnectorNonNative.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.26;
+pragma solidity ^0.8.26;
 
 import "forge-std/Script.sol";
 import "contracts/evm/ZetaConnectorNonNative.sol";

--- a/scripts/deploy/deterministic/UpgradeGatewayEVM.s.sol
+++ b/scripts/deploy/deterministic/UpgradeGatewayEVM.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.26;
+pragma solidity ^0.8.26;
 
 import "forge-std/Script.sol";
 import "contracts/evm/GatewayEVM.sol";

--- a/scripts/upgrade/SimulateERC20CustodyUpgrade.s.sol
+++ b/scripts/upgrade/SimulateERC20CustodyUpgrade.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.26;
+pragma solidity ^0.8.26;
 
 import "forge-std/console.sol";
 import "forge-std/Script.sol";

--- a/scripts/upgrade/SimulateGatewayEVMUpgrade.s.sol
+++ b/scripts/upgrade/SimulateGatewayEVMUpgrade.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.26;
+pragma solidity ^0.8.26;
 
 import "forge-std/console.sol";
 import "forge-std/Script.sol";

--- a/scripts/upgrade/SimulateGatewayZEVMUpgrade.s.sol
+++ b/scripts/upgrade/SimulateGatewayZEVMUpgrade.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.26;
+pragma solidity ^0.8.26;
 
 import "forge-std/console.sol";
 import "forge-std/Script.sol";

--- a/test/ERC20Custody.t.sol
+++ b/test/ERC20Custody.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.26;
+pragma solidity ^0.8.26;
 
 import "forge-std/Test.sol";
 import "forge-std/Vm.sol";

--- a/test/GatewayEVM.t.sol
+++ b/test/GatewayEVM.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.26;
+pragma solidity ^0.8.26;
 
 import "forge-std/Test.sol";
 import "forge-std/Vm.sol";

--- a/test/GatewayEVMZEVM.t.sol
+++ b/test/GatewayEVMZEVM.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.26;
+pragma solidity ^0.8.26;
 
 import "forge-std/Test.sol";
 import "forge-std/Vm.sol";

--- a/test/GatewayZEVM.t.sol
+++ b/test/GatewayZEVM.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.26;
+pragma solidity ^0.8.26;
 
 import "forge-std/Test.sol";
 import "forge-std/Vm.sol";

--- a/test/ZRC20.t.sol
+++ b/test/ZRC20.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.26;
+pragma solidity ^0.8.26;
 
 import "forge-std/Test.sol";
 import "forge-std/Vm.sol";

--- a/test/ZetaConnectorNative.t.sol
+++ b/test/ZetaConnectorNative.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.26;
+pragma solidity ^0.8.26;
 
 import "forge-std/Test.sol";
 import "forge-std/Vm.sol";

--- a/test/ZetaConnectorNonNative.t.sol
+++ b/test/ZetaConnectorNonNative.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.26;
+pragma solidity ^0.8.26;
 
 import "forge-std/Test.sol";
 import "forge-std/Vm.sol";

--- a/test/fuzz/ERC20CustodyEchidnaTest.sol
+++ b/test/fuzz/ERC20CustodyEchidnaTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.26;
+pragma solidity ^0.8.26;
 
 // TODO: https://github.com/zeta-chain/protocol-contracts/issues/384
 

--- a/test/fuzz/GatewayEVMEchidnaTest.sol
+++ b/test/fuzz/GatewayEVMEchidnaTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.26;
+pragma solidity ^0.8.26;
 
 // TODO: https://github.com/zeta-chain/protocol-contracts/issues/384
 

--- a/test/utils/IReceiverEVM.sol
+++ b/test/utils/IReceiverEVM.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.26;
+pragma solidity ^0.8.26;
 
 import { RevertContext } from "../../contracts/Revert.sol";
 

--- a/test/utils/ReceiverEVM.sol
+++ b/test/utils/ReceiverEVM.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.26;
+pragma solidity ^0.8.26;
 
 import { RevertContext } from "../../contracts/Revert.sol";
 import { MessageContext } from "../../contracts/evm/interfaces/IGatewayEVM.sol";

--- a/test/utils/SenderZEVM.sol
+++ b/test/utils/SenderZEVM.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.26;
+pragma solidity ^0.8.26;
 
 import { IGatewayZEVM } from "../../contracts/zevm/interfaces/IGatewayZEVM.sol";
 import { CallOptions, RevertOptions } from "../../contracts/zevm/interfaces/IGatewayZEVM.sol";

--- a/test/utils/SystemContractMock.sol
+++ b/test/utils/SystemContractMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.26;
+pragma solidity ^0.8.26;
 
 import "../../contracts/zevm/interfaces/IZRC20.sol";
 import "../../contracts/zevm/interfaces/UniversalContract.sol";

--- a/test/utils/TestERC20.sol
+++ b/test/utils/TestERC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.26;
+pragma solidity ^0.8.26;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 

--- a/test/utils/TestUniversalContract.sol
+++ b/test/utils/TestUniversalContract.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.26;
+pragma solidity ^0.8.26;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 

--- a/test/utils/WZETA.sol
+++ b/test/utils/WZETA.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.26;
+pragma solidity ^0.8.26;
 
 contract WETH9 {
     string public name = "Wrapped Ether";

--- a/test/utils/Zeta.non-eth.sol
+++ b/test/utils/Zeta.non-eth.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.26;
+pragma solidity ^0.8.26;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";

--- a/test/utils/upgrades/ERC20CustodyUpgradeTest.sol
+++ b/test/utils/upgrades/ERC20CustodyUpgradeTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.26;
+pragma solidity ^0.8.26;
 
 import { IERC20Custody } from "../../../contracts/evm/interfaces/IERC20Custody.sol";
 import { IGatewayEVM, MessageContext } from "../../../contracts/evm/interfaces/IGatewayEVM.sol";

--- a/test/utils/upgrades/GatewayEVMUpgradeTest.sol
+++ b/test/utils/upgrades/GatewayEVMUpgradeTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.26;
+pragma solidity ^0.8.26;
 
 import { INotSupportedMethods } from "../../../contracts/Errors.sol";
 import { RevertContext, RevertOptions, Revertable } from "../../../contracts/Revert.sol";

--- a/test/utils/upgrades/GatewayZEVMUpgradeTest.sol
+++ b/test/utils/upgrades/GatewayZEVMUpgradeTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.26;
+pragma solidity ^0.8.26;
 
 import { CallOptions, IGatewayZEVM } from "../../../contracts/zevm/interfaces/IGatewayZEVM.sol";
 

--- a/test/utils/upgrades/ZetaConnectorNativeUpgradeTest.sol
+++ b/test/utils/upgrades/ZetaConnectorNativeUpgradeTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.26;
+pragma solidity ^0.8.26;
 
 import "../../../contracts/evm/ZetaConnectorBase.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/test/utils/upgrades/ZetaConnectorNonNativeUpgradeTest.sol
+++ b/test/utils/upgrades/ZetaConnectorNonNativeUpgradeTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.26;
+pragma solidity ^0.8.26;
 
 import "../../../contracts/evm/ZetaConnectorBase.sol";
 import "../../../contracts/evm/interfaces/IZetaNonEthNew.sol";


### PR DESCRIPTION
Addresses https://github.com/zeta-chain/protocol-contracts/issues/441

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated Solidity version pragma from `0.8.26` to `^0.8.26` across multiple contract files
  - Allows for compatibility with future minor and patch updates of Solidity 0.8.x

- **Documentation**
  - Added deprecation notes for certain structs and interfaces in `UniversalContract`

- **New Features**
  - Introduced `MessageContext` struct and `UniversalContract` interface in `UniversalContract.sol`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->