### PR TITLE
fix: skip admin transfer in deployment scripts when admin is deployer

### DIFF
--- a/scripts/deploy/deterministic/DeployERC20Custody.s.sol
+++ b/scripts/deploy/deterministic/DeployERC20Custody.s.sol
@@ -60,7 +60,9 @@ contract DeployERC20Custody is Script {
         require(address(erc20Custody.gateway()) == gateway, "gateway not set");
 
         // Transfer admin role from deployer to admin
-        transferAdmin(erc20Custody, msg.sender, admin);
+        if (msg.sender != admin) {
+            transferAdmin(erc20Custody, msg.sender, admin);
+        }
 
         vm.stopBroadcast();
     }

--- a/scripts/deploy/deterministic/DeployGatewayEVM.s.sol
+++ b/scripts/deploy/deterministic/DeployGatewayEVM.s.sol
@@ -60,9 +60,10 @@ contract DeployGatewayEVM is Script {
         require(gateway.tssAddress() == tss, "tss not set");
         require(gateway.zetaToken() == address(zeta), "zeta token not set");
 
-        // Transfer admin role from deployer to admin
-        transferAdmin(gateway, msg.sender, admin);
-
+        // Transfer admin role from deployer to admin if the address is different
+        if (msg.sender != admin) {
+            transferAdmin(gateway, msg.sender, admin);
+        }
         vm.stopBroadcast();
     }
 

--- a/scripts/deploy/deterministic/DeployGatewayZEVM.s.sol
+++ b/scripts/deploy/deterministic/DeployGatewayZEVM.s.sol
@@ -58,7 +58,9 @@ contract DeployGatewayZEVM is Script {
         require(gateway.zetaToken() == zeta, "zeta token not set");
 
         // Transfer admin role from deployer to admin
-        transferAdmin(gateway, msg.sender, admin);
+        if (msg.sender != admin) {
+            transferAdmin(gateway, msg.sender, admin);
+        }
 
         vm.stopBroadcast();
     }


### PR DESCRIPTION
If the admin is the deployer (which could be the case for testnet or some other testing), we have an issue in the scripts where renounceRole would be called with the actual admin address, meaning the contract end up with no admin at all
```
        gateway.renounceRole(gateway.PAUSER_ROLE(), deployer);
        gateway.renounceRole(gateway.DEFAULT_ADMIN_ROLE(), deployer);
```

This change skips this logic if the deployer is the admin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security Improvements**
	- Enhanced admin role transfer logic across multiple deployment scripts
	- Added conditional checks to prevent unnecessary or redundant admin role transfers
	- Improved control flow for role assignment during contract deployment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->