### PR TITLE
chore: Rename discord webhook secret

### DIFF
--- a/.github/workflows/release-to-discord.yaml
+++ b/.github/workflows/release-to-discord.yaml
@@ -12,7 +12,7 @@ jobs:
       - name: Github Releases To Discord
         uses: SethCohen/github-releases-to-discord@v1.16.2
         with:
-          webhook_url: ${{ secrets.WEBHOOK_URL }}
+          webhook_url: ${{ secrets.DISCORD_WEBHOOK_URL }}
           color: "2105893"
           username: "New Release: Protocol Contracts"
           max_description: "4096"

--- a/.github/workflows/release-to-discord.yaml
+++ b/.github/workflows/release-to-discord.yaml
@@ -12,7 +12,7 @@ jobs:
       - name: Github Releases To Discord
         uses: SethCohen/github-releases-to-discord@v1.16.2
         with:
-          webhook_url: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          webhook_url: ${{ secrets.DISCORD_DEVZONE_RELEASE_ANNOUNCEMENTS_WEBHOOK_URL }}
           color: "2105893"
           username: "New Release: Protocol Contracts"
           max_description: "4096"


### PR DESCRIPTION
Renaming the discord webhook secret to be self-descriptive. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated internal configuration for release notifications to Discord. No changes to user-facing features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->