### PR TITLE
feat: add custom gas limit support for ZRC20 withdrawals

### DIFF
--- a/contracts/zevm/GatewayZEVM.sol
+++ b/contracts/zevm/GatewayZEVM.sol
@@ -286,6 +286,42 @@ contract GatewayZEVM is
         );
     }
 
+    /// @notice Withdraw ZRC20 tokens to an external chain with custom gas limit.
+    /// @dev Use this function for simple gas ZRC20 withdrawals to the receivers that are
+    ///      either smart contract accounts or smart contracts with custom receive/fallback implementations.
+    /// @param receiver The receiver address on the external chain.
+    /// @param amount The amount of tokens to withdraw.
+    /// @param gasLimit The custom gas limit for the withdrawal (must be >= MIN_GAS_LIMIT).
+    /// @param zrc20 The address of the ZRC20 token.
+    /// @param revertOptions Revert options.
+    function withdraw(
+        bytes memory receiver,
+        uint256 amount,
+        uint256 gasLimit,
+        address zrc20,
+        RevertOptions calldata revertOptions
+    )
+        external
+        whenNotPaused
+    {
+        GatewayZEVMValidations.validateWithdrawalParams(receiver, amount, revertOptions);
+        GatewayZEVMValidations.validateGasLimit(gasLimit);
+
+        uint256 gasFee = _withdrawZRC20WithGasLimit(amount, zrc20, gasLimit);
+        emit Withdrawn(
+            msg.sender,
+            0,
+            receiver,
+            zrc20,
+            amount,
+            gasFee,
+            IZRC20(zrc20).PROTOCOL_FLAT_FEE(),
+            "",
+            CallOptions({ gasLimit: gasLimit, isArbitraryCall: true }),
+            revertOptions
+        );
+    }
+
     /// @notice Withdraw ZRC20 tokens and call a smart contract on an external chain.
     /// @param receiver The receiver address on the external chain.
     /// @param amount The amount of tokens to withdraw.


### PR DESCRIPTION
Implement new withdrawal function with custom gas limit setting in the GatewayZEVM. Should be used for gas ZRC20 withdrawals when the receiver is a smart contract or smart contract account with custom receive/fallback implementation.

Closes: https://github.com/zeta-chain/protocol-contracts/issues/547

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for ZRC20 token withdrawals to external chains with a user-specified custom gas limit, offering more flexibility for advanced withdrawal scenarios.

* **Tests**
  * Introduced comprehensive tests for the new withdrawal feature, covering successful transactions and various failure cases related to gas limits and input validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->