### PR TITLE
feat: add ExtendedMessageContext with asset and amount info

### DIFF
--- a/contracts/evm/GatewayEVM.sol
+++ b/contracts/evm/GatewayEVM.sol
@@ -440,14 +440,14 @@ contract GatewayEVM is
         private
         returns (bytes memory)
     {
-        // Try standard Callable interface first.
-        MessageContextV2 memory messageContextV2 =
-            MessageContextV2({ sender: messageContext.sender, asset: asset, amount: amount });
-        try Callable(destination).onCall{ value: msg.value }(messageContextV2, data) returns (bytes memory result) {
+        // Try legacy Callable interface first.
+        try LegacyCallable(destination).onCall{ value: msg.value }(messageContext, data) returns (bytes memory result) {
             return result;
         } catch {
-            // Contract doesn't support standard interface, try legacy with interface.
-            return LegacyCallable(destination).onCall{ value: msg.value }(messageContext, data);
+            // Contract doesn't support legacy interface, try with standard interface.
+            MessageContextV2 memory messageContextV2 =
+                MessageContextV2({ sender: messageContext.sender, asset: asset, amount: amount });
+            return Callable(destination).onCall{ value: msg.value }(messageContextV2, data);
         }
     }
 

--- a/contracts/evm/interfaces/IGatewayEVM.sol
+++ b/contracts/evm/interfaces/IGatewayEVM.sol
@@ -229,24 +229,18 @@ struct MessageContext {
 /// @param sender Sender from omnichain contract.
 /// @param asset Address of token that is sent cross chain.
 /// @param amount The amount of the token.
-struct ExtendedMessageContext {
+struct MessageContextV2 {
     address sender;
     address asset;
     uint256 amount;
 }
 
 /// @notice Interface implemented by contracts receiving authenticated calls.
-interface Callable {
+interface LegacyCallable {
     function onCall(MessageContext calldata context, bytes calldata message) external payable returns (bytes memory);
 }
 
 /// @notice Interface implemented by contracts receiving authenticated calls with extended message context.
-interface ExtendedCallable {
-    function onCall(
-        ExtendedMessageContext calldata context,
-        bytes memory message
-    )
-        external
-        payable
-        returns (bytes memory);
+interface Callable {
+    function onCall(MessageContextV2 calldata context, bytes memory message) external payable returns (bytes memory);
 }

--- a/contracts/evm/interfaces/IGatewayEVM.sol
+++ b/contracts/evm/interfaces/IGatewayEVM.sol
@@ -225,7 +225,28 @@ struct MessageContext {
     address sender;
 }
 
+/// @notice Message context passed to execute function.
+/// @param sender Sender from omnichain contract.
+/// @param asset Address of token that is sent cross chain.
+/// @param amount The amount of the token.
+struct ExtendedMessageContext {
+    address sender;
+    address asset;
+    uint256 amount;
+}
+
 /// @notice Interface implemented by contracts receiving authenticated calls.
 interface Callable {
     function onCall(MessageContext calldata context, bytes calldata message) external payable returns (bytes memory);
+}
+
+/// @notice Interface implemented by contracts receiving authenticated calls with extended message context.
+interface ExtendedCallable {
+    function onCall(
+        ExtendedMessageContext calldata context,
+        bytes memory message
+    )
+        external
+        payable
+        returns (bytes memory);
 }


### PR DESCRIPTION
Add asset and amount information to the onCall hook on connected chains through a new ExtendedMessageContext struct.

Closes: https://github.com/zeta-chain/protocol-contracts/issues/426
