### PR TITLE
refactor: extract common validation logic into GatewayEVMValidations library

### DIFF
--- a/contracts/evm/interfaces/IGatewayEVM.sol
+++ b/contracts/evm/interfaces/IGatewayEVM.sol
@@ -82,11 +82,8 @@ interface IGatewayEVMErrors {
     /// @notice Error for failed deposit.
     error DepositFailed();
 
-    /// @notice Error for insufficient ETH amount.
-    error InsufficientETHAmount();
-
-    /// @notice Error for insufficient ERC20 token amount.
-    error InsufficientERC20Amount();
+    /// @notice Error for insufficient token amount.
+    error InsufficientEVMAmount();
 
     /// @notice Error for zero address input.
     error ZeroAddress();

--- a/contracts/evm/libraries/GatewayEVMValidations.sol
+++ b/contracts/evm/libraries/GatewayEVMValidations.sol
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import "../../../contracts/Errors.sol";
+import "../../../contracts/Revert.sol";
+import "../interfaces/IGatewayEVM.sol";
+
+/// @title GatewayEVMValidations
+/// @notice Library containing validation functions for GatewayEVM contract.
+/// @dev This library provides common validation logic used across GatewayEVM contract.
+library GatewayEVMValidations {
+    /// @notice Maximum payload size constant.
+    uint256 internal constant MAX_PAYLOAD_SIZE = 2880;
+
+    /// @dev Validates that an address is not zero.
+    /// @param addr The address to validate.
+    function validateNonZeroAddress(address addr) internal pure {
+        if (addr == address(0)) revert IGatewayEVMErrors.ZeroAddress();
+    }
+
+    /// @dev Validates that amount is not zero.
+    /// @param amount The amount to validate.
+    function validateAmount(uint256 amount) internal pure {
+        if (amount == 0) revert IGatewayEVMErrors.InsufficientEVMAmount();
+    }
+
+    /// @dev Validates payload size constraints.
+    /// @param payloadLength The length of the main payload.
+    /// @param revertMessageLength The length of the revert message.
+    function validatePayloadSize(uint256 payloadLength, uint256 revertMessageLength) internal pure {
+        uint256 totalSize = payloadLength + revertMessageLength;
+        if (payloadLength + revertMessageLength > MAX_PAYLOAD_SIZE) {
+            revert IGatewayEVMErrors.PayloadSizeExceeded(totalSize, MAX_PAYLOAD_SIZE);
+        }
+    }
+
+    /// @dev Validates on revert gas limit.
+    /// @param revertOptions The revert options to validate.
+    function validateGasLimitRevertOptions(RevertOptions calldata revertOptions) internal pure {
+        if (revertOptions.onRevertGasLimit > MAX_REVERT_GAS_LIMIT) {
+            revert RevertGasLimitExceeded(revertOptions.onRevertGasLimit, MAX_REVERT_GAS_LIMIT);
+        }
+    }
+
+    /// @dev Validates on revert message length.
+    /// @param revertOptions The revert options to validate.
+    function validateRevertMessageLength(RevertOptions calldata revertOptions) internal pure {
+        if (revertOptions.revertMessage.length > MAX_PAYLOAD_SIZE) {
+            revert IGatewayEVMErrors.PayloadSizeExceeded(revertOptions.revertMessage.length, MAX_PAYLOAD_SIZE);
+        }
+    }
+
+    /// @dev Validates revert options for call operations (includes callOnRevert check).
+    /// @param revertOptions The revert options to validate.
+    function validateCallRevertOptions(RevertOptions calldata revertOptions) internal pure {
+        if (revertOptions.callOnRevert) revert INotSupportedMethods.CallOnRevertNotSupported();
+        validateGasLimitRevertOptions(revertOptions);
+    }
+
+    /// @dev Validates standard deposit parameters.
+    /// @param receiver The receiver address.
+    /// @param amount The amount to deposit.
+    /// @param revertOptions The revert options.
+    function validateDepositParams(
+        address receiver,
+        uint256 amount,
+        RevertOptions calldata revertOptions
+    )
+        internal
+        pure
+    {
+        validateNonZeroAddress(receiver);
+        validateAmount(amount);
+        validateRevertMessageLength(revertOptions);
+        validateGasLimitRevertOptions(revertOptions);
+    }
+
+    /// @dev Validates deposit and call parameters.
+    /// @param receiver The receiver address.
+    /// @param amount The amount to deposit.
+    /// @param payload The payload to send.
+    /// @param revertOptions The revert options.
+    function validateDepositAndCallParams(
+        address receiver,
+        uint256 amount,
+        bytes calldata payload,
+        RevertOptions calldata revertOptions
+    )
+        internal
+        pure
+    {
+        validateNonZeroAddress(receiver);
+        validateAmount(amount);
+        validatePayloadSize(payload.length, revertOptions.revertMessage.length);
+        validateGasLimitRevertOptions(revertOptions);
+    }
+
+    /// @dev Validates call parameters.
+    /// @param receiver The receiver address.
+    /// @param payload The payload to send.
+    /// @param revertOptions The revert options.
+    function validateCallParams(
+        address receiver,
+        bytes calldata payload,
+        RevertOptions calldata revertOptions
+    )
+        internal
+        pure
+    {
+        validateNonZeroAddress(receiver);
+        validateCallRevertOptions(revertOptions);
+        validatePayloadSize(payload.length, revertOptions.revertMessage.length);
+    }
+}

--- a/contracts/zevm/libraries/GatewayZEVMValidations.sol
+++ b/contracts/zevm/libraries/GatewayZEVMValidations.sol
@@ -53,8 +53,9 @@ library GatewayZEVMValidations {
     /// @param messageLength The length of the main message
     /// @param revertMessageLength The length of the revert message
     function validateMessageSize(uint256 messageLength, uint256 revertMessageLength) internal pure {
-        if (messageLength + revertMessageLength > MAX_MESSAGE_SIZE) {
-            revert IGatewayZEVMErrors.MessageSizeExceeded(messageLength + revertMessageLength, MAX_MESSAGE_SIZE);
+        uint256 totalSize = messageLength + revertMessageLength;
+        if (totalSize > MAX_MESSAGE_SIZE) {
+            revert IGatewayZEVMErrors.MessageSizeExceeded(totalSize, MAX_MESSAGE_SIZE);
         }
     }
 

--- a/test/ERC20Custody.t.sol
+++ b/test/ERC20Custody.t.sol
@@ -292,7 +292,7 @@ contract ERC20CustodyTest is Test, IGatewayEVMErrors, IGatewayEVMEvents, IReceiv
             abi.encodeWithSignature("receiveERC20(uint256,address,address)", amount, address(token), destination);
 
         vm.prank(tssAddress);
-        vm.expectRevert(InsufficientERC20Amount.selector);
+        vm.expectRevert(InsufficientEVMAmount.selector);
         custody.withdrawAndCall(arbitraryCallMessageContext, address(receiver), address(token), amount, data);
     }
 
@@ -408,7 +408,7 @@ contract ERC20CustodyTest is Test, IGatewayEVMErrors, IGatewayEVMEvents, IReceiv
             abi.encodeWithSignature("receiveERC20Partial(uint256,address,address)", amount, address(token), destination);
 
         vm.prank(tssAddress);
-        vm.expectRevert(InsufficientERC20Amount.selector);
+        vm.expectRevert(InsufficientEVMAmount.selector);
         custody.withdrawAndCall(arbitraryCallMessageContext, address(receiver), address(token), amount, data);
     }
 
@@ -557,7 +557,7 @@ contract ERC20CustodyTest is Test, IGatewayEVMErrors, IGatewayEVMEvents, IReceiv
         bytes memory data = abi.encodePacked("hello");
 
         vm.prank(tssAddress);
-        vm.expectRevert(InsufficientERC20Amount.selector);
+        vm.expectRevert(InsufficientEVMAmount.selector);
         custody.withdrawAndRevert(address(receiver), address(token), amount, data, revertContext);
     }
 

--- a/test/GatewayEVM.t.sol
+++ b/test/GatewayEVM.t.sol
@@ -627,7 +627,7 @@ contract GatewayEVMInboundTest is
 
         token.approve(address(gateway), amount);
 
-        vm.expectRevert(InsufficientERC20Amount.selector);
+        vm.expectRevert(InsufficientEVMAmount.selector);
         gateway.deposit(destination, amount, address(token), revertOptions);
     }
 
@@ -652,7 +652,7 @@ contract GatewayEVMInboundTest is
     function testDepositEthToTssFailsIfAmountIs0() public {
         uint256 amount = 0;
 
-        vm.expectRevert(InsufficientETHAmount.selector);
+        vm.expectRevert(InsufficientEVMAmount.selector);
         gateway.deposit{ value: amount }(destination, revertOptions);
     }
 
@@ -703,7 +703,7 @@ contract GatewayEVMInboundTest is
     function testDepositEthWithAmountToTssFailsIfAmountIs0() public {
         uint256 amount = 0;
 
-        vm.expectRevert(InsufficientETHAmount.selector);
+        vm.expectRevert(InsufficientEVMAmount.selector);
         gateway.deposit{ value: amount }(destination, amount, revertOptions);
     }
 
@@ -800,7 +800,7 @@ contract GatewayEVMInboundTest is
 
         bytes memory payload = abi.encodeWithSignature("hello(address)", destination);
 
-        vm.expectRevert(InsufficientERC20Amount.selector);
+        vm.expectRevert(InsufficientEVMAmount.selector);
         gateway.depositAndCall(destination, amount, address(token), payload, revertOptions);
     }
 
@@ -881,7 +881,7 @@ contract GatewayEVMInboundTest is
         uint256 amount = 0;
         bytes memory payload = abi.encodeWithSignature("hello(address)", destination);
 
-        vm.expectRevert(InsufficientETHAmount.selector);
+        vm.expectRevert(InsufficientEVMAmount.selector);
         gateway.depositAndCall{ value: amount }(destination, payload, revertOptions);
     }
 
@@ -961,7 +961,7 @@ contract GatewayEVMInboundTest is
         uint256 amount = 0;
         bytes memory payload = abi.encodeWithSignature("hello(address)", destination);
 
-        vm.expectRevert(InsufficientETHAmount.selector);
+        vm.expectRevert(InsufficientEVMAmount.selector);
         gateway.depositAndCall{ value: amount }(destination, amount, payload, revertOptions);
     }
 
@@ -1235,7 +1235,7 @@ contract GatewayEVMInboundTest is
         gateway.deposit{ value: amount }(destination, revertOptions);
 
         // Second deposit with only fee amount should fail because depositAmount = 0
-        vm.expectRevert(InsufficientETHAmount.selector);
+        vm.expectRevert(InsufficientEVMAmount.selector);
         gateway.deposit{ value: ADDITIONAL_ACTION_FEE_WEI }(destination, 0, revertOptions);
     }
 


### PR DESCRIPTION
Refactors duplicate validation checks in GatewayEVM contract by extracting them into a dedicated validation library.

Closing: https://github.com/zeta-chain/protocol-contracts/issues/511